### PR TITLE
Fix links to model outputs in summaries.

### DIFF
--- a/all-reports.py
+++ b/all-reports.py
@@ -59,15 +59,8 @@ def getTagOrVersion(v):
 def libraryLink(branch, libname):
   return '<a href="%s/%s/%s/%s.html">%s</a>' % (baseurl,branch,libname,libname,libname)
 
-def is_non_zero_file(fpath):
-    return os.path.isfile(fpath) and os.path.getsize(fpath) > 0
-
 def modelLink(libname, modelname, extension):
-  filename = "files/%s_%s.%s" % (libname, modelname, extension)
-  if is_non_zero_file(filename):
-    return '<a href="%s">%s</a>' % (filename, modelname)
-  else:
-    return modelname
+  return '<a href="%s/%s/%s/files/%s_%s.%s">%s</a>' % (baseurl,branch,libname,libname,modelname,extension,modelname)
 
 emails_to_send = {}
 for branch in branches:
@@ -184,7 +177,7 @@ for branch in branches:
         else:
           numPerformanceRegression += 1
         msg = " ".join(msgs)
-      regstrs.append('<tr><td>%s</td><td>%s</td><td class="%s">%s</td></tr>' % (libraryLink(branch, libname),modelLink(libname, model, ".err"),color,msg))
+      regstrs.append('<tr><td>%s</td><td>%s</td><td class="%s">%s</td></tr>' % (libraryLink(branch, libname),modelLink(libname, model, "err"),color,msg))
     tpl = tpl.replace("#NUMIMPROVE#",str(numImproved)).replace("#NUMREGRESSION#",str(numRegression)).replace("#NUMPERFIMPROVE#",str(numPerformanceImproved)).replace("#NUMPERFREGRESSION#",str(numPerformanceRegression)).replace("#MODELCHANGES#", "\n".join(regstrs))
     tpl = tpl.replace("#BRANCH#",branch).replace("#DATE1#",dateStr(d1)).replace("#DATE2#",dateStr(d2))
 


### PR DESCRIPTION
- Generate absolute urls for model outputs in summaries, similar to how
  libraries are linked.
- Skip check for file existance before generating links, since it
  doesn't work and the files seem to always exist anyway.