### PR TITLE
Remove KeyWordIO library as a temporary fix.

### DIFF
--- a/configs/conf.json
+++ b/configs/conf.json
@@ -190,9 +190,6 @@
     "library":"IdealizedContact"
   },
   {
-    "library":"KeyWordIO"
-  },
-  {
     "library":"LibRAS",
     "extraCustomCommands":["if not setCommandLineOptions(\"--std=3.3\") then exit(1); end if;"]
   },


### PR DESCRIPTION
 PING!
 
 - The Coverage reports are not being generated right now because this
    library is misconfigured. Something about a missing "master" branch.

  - This does not have to be merged if it is fixed properly soon. I just could
    not figure out how the branches names are interpreted to fix it properly.

    The missing branch is "master". The index file list these branches as available
        0.0.0+X.0
        0.1.0
        0.10.0+X
        0.10.0-master+X
        0.2.0
        0.4.0
        0.5.0
        0.6.0
        0.7.0
        0.8.0
        0.9.0

  There is even a comment regarding this in the `installLibraries.mos` file here
 https://github.com/OpenModelica/OpenModelicaLibraryTesting/blob/ee2a505481a0d79ccc204ec961bd9ee87faa3c06/.CI/installLibraries.mos#L19-L26