### PR TITLE
Reference files for ClaRa_dev

### DIFF
--- a/configs/conf.json
+++ b/configs/conf.json
@@ -170,7 +170,7 @@
     ],
     "referenceFileExtension":"mat",
     "referenceFileNameDelimiter":".",
-    "referenceFiles":"$/mnt/ReferenceFiles/ExtraLibs/packaged/ReferenceResults"
+    "referenceFiles":"/mnt/ReferenceFiles/ExtraLibs/packaged/ReferenceResults"
   },
   {
     "library":"ConPNlib",

--- a/configs/conf.json
+++ b/configs/conf.json
@@ -167,7 +167,11 @@
     "loadFileCommands":[
       "loadModel(TILMedia, {\"main\"})",
       "loadFile(\"/mnt/ReferenceFiles/ExtraLibs/packaged/ClaRa/package.mo\")"
-    ]
+    ],
+    "referenceFileExtension":"mat",
+    "referenceFileNameDelimiter":".",
+    "referenceFileNameExtraName":"$ClassName",
+    "referenceFiles":"$/mnt/ReferenceFiles/ExtraLibs/packaged/ReferenceResults"
   },
   {
     "library":"ConPNlib",

--- a/configs/conf.json
+++ b/configs/conf.json
@@ -170,7 +170,6 @@
     ],
     "referenceFileExtension":"mat",
     "referenceFileNameDelimiter":".",
-    "referenceFileNameExtraName":"$ClassName",
     "referenceFiles":"$/mnt/ReferenceFiles/ExtraLibs/packaged/ReferenceResults"
   },
   {


### PR DESCRIPTION
The developer version of ClaRa now has result files in `ReferenceResults/` looking like
`ReferenceResults/ClaRa.Basics.ControlVolumes.FluidVolumes.Check.Validation_VolumeVLE_L2_HeatTransfer_1ph_shell.mat`.

Adding reference files to library test configuration.