### PR TITLE
Support for running heavy tests one at a time

### DIFF
--- a/.CI/Jenkinsfile
+++ b/.CI/Jenkinsfile
@@ -36,6 +36,7 @@ pipeline {
     booleanParam(name: 'cvode', defaultValue: false, description: 'master branch, with -d=newInst and -s cvode (ryzen-5950x-2). This is an experimental job that does not run on a fixed schedule.')
     booleanParam(name: 'gbode', defaultValue: false, description: 'master branch, with -d=newInst and -s gbode (ryzen-5950x-2). This is an experimental job that does not run on a fixed schedule.')
     booleanParam(name: 'generateSymbolicJacobian', defaultValue: false, description: 'master branch, with --generateSymbolicJacobian (ryzen-5950x-1). This is an experimental job that does not run on a fixed schedule.')
+    booleanParam(name: 'heavy_tests', defaultValue: false, description: 'master branch, runs one test at a time. That is, no parallel launching of tests. omc will use multiple threads for each test (-n=1 is not set unlike the other regression tests.), (ryzen-5950x-2). This is an experimental job that does not run on a fixed schedule.')
   }
   environment {
     LC_ALL = 'C.UTF-8'
@@ -454,6 +455,22 @@ pipeline {
           runRegressiontest('master', 'generateSymbolicJacobian', 'setCommandLineOptions("--generateSymbolicJacobian")', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
         }
       }
+      stage('heavy_tests') {
+        agent {
+          node {
+            label 'ryzen-5950x-2-1'
+            customWorkspace 'ws/OpenModelicaLibraryTestingWork'
+          }
+        }
+        options { skipDefaultCheckout() }
+        when {
+          beforeAgent true
+          expression { params.heavy_tests }
+        }
+        steps {
+          runRegressiontest('master', 'heavy_tests', '', '', 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false, 1)
+        }
+      }
       stage('C++ v1.18') {
         agent {
           node {
@@ -587,7 +604,7 @@ pipeline {
         }
         when {
           beforeAgent true
-          expression { params.fmi_v1_12 || params.fmi_v1_13 || params.fmi_v1_14 || params.fmi_v1_16 || params.fmi_v1_17 || params.fmi_master || params.newInst_daeMode  || params.oldInst || params.report_ryzen_5950x_2 || params.cpp || params.cvode || params.gbode}
+          expression { params.fmi_v1_12 || params.fmi_v1_13 || params.fmi_v1_14 || params.fmi_v1_16 || params.fmi_v1_17 || params.fmi_master || params.newInst_daeMode  || params.oldInst || params.report_ryzen_5950x_2 || params.cpp || params.cvode || params.gbode || params.heavy_tests}
         }
         environment {
           GITBRANCHES_FMI = 'maintenance/v1.12-fmi maintenance/v1.13-fmi maintenance/v1.14-fmi maintenance/v1.16-fmi maintenance/v1.17-fmi maintenance/v1.18-fmi maintenance/v1.19-fmi maintenance/v1.20-fmi master-fmi'
@@ -644,6 +661,9 @@ pipeline {
 
           sh "./report.py --branches='gbode' configs/conf.json"
           sh "mv overview.html overview-gbode.html"
+
+          sh "./report.py --branches='heavy_tests' configs/conf.json"
+          sh "mv overview.html overview-heavy_tests.html"
 
           sh "./report.py --branches='${env.GITBRANCHES_CPP}' configs/conf.json"
           sh "mv overview.html overview-c++.html"

--- a/.CI/Jenkinsfile
+++ b/.CI/Jenkinsfile
@@ -56,7 +56,7 @@ pipeline {
           expression { params.v1_12 }
         }
         steps {
-          test('maintenance/v1.12', 'v1.12', '', '', 'ripper1', 'LibraryTestingRipper1DB', true, '', true, false)
+          runRegressiontest('maintenance/v1.12', 'v1.12', '', '', 'ripper1', 'LibraryTestingRipper1DB', true, '', true, false)
         }
       }
 
@@ -73,7 +73,7 @@ pipeline {
           expression { params.v1_13 }
         }
         steps {
-          test('maintenance/v1.13', 'v1.13', '', '', 'ripper1', 'LibraryTestingRipper1DB', true, '', true, false)
+          runRegressiontest('maintenance/v1.13', 'v1.13', '', '', 'ripper1', 'LibraryTestingRipper1DB', true, '', true, false)
         }
       }
 
@@ -90,7 +90,7 @@ pipeline {
           expression { params.v1_14 }
         }
         steps {
-          test('maintenance/v1.14', 'v1.14', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', true, false)
+          runRegressiontest('maintenance/v1.14', 'v1.14', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', true, false)
         }
       }
 
@@ -107,7 +107,7 @@ pipeline {
           expression { params.v1_16 }
         }
         steps {
-          test('maintenance/v1.16', 'v1.16', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
+          runRegressiontest('maintenance/v1.16', 'v1.16', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
         }
       }
 
@@ -124,7 +124,7 @@ pipeline {
           expression { params.v1_17 }
         }
         steps {
-          test('maintenance/v1.17', 'v1.17', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
+          runRegressiontest('maintenance/v1.17', 'v1.17', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
         }
       }
 
@@ -141,7 +141,7 @@ pipeline {
           expression { params.v1_18 }
         }
         steps {
-          test('maintenance/v1.18', 'v1.18', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
+          runRegressiontest('maintenance/v1.18', 'v1.18', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
         }
       }
 
@@ -158,7 +158,7 @@ pipeline {
           expression { params.v1_19 }
         }
         steps {
-          test('maintenance/v1.19', 'v1.19', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
+          runRegressiontest('maintenance/v1.19', 'v1.19', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
         }
       }
 
@@ -175,7 +175,7 @@ pipeline {
           expression { params.v1_20 }
         }
         steps {
-          test('maintenance/v1.20', 'v1.20', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
+          runRegressiontest('maintenance/v1.20', 'v1.20', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
         }
       }
 
@@ -192,7 +192,7 @@ pipeline {
           expression { params.master }
         }
         steps {
-          test('master', 'master', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
+          runRegressiontest('master', 'master', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
         }
       }
 
@@ -209,7 +209,7 @@ pipeline {
           expression { params.conversion_script }
         }
         steps {
-          test('master', 'conversion', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, true)
+          runRegressiontest('master', 'conversion', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, true)
         }
       }
 
@@ -226,7 +226,7 @@ pipeline {
           expression { params.newInst_newBackend }
         }
         steps {
-          test('master', 'newInst-newBackend', 'setCommandLineOptions("-d=newInst,-frontEndUnitCheck --newBackend")', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
+          runRegressiontest('master', 'newInst-newBackend', 'setCommandLineOptions("-d=newInst,-frontEndUnitCheck --newBackend")', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
         }
       }
 
@@ -243,7 +243,7 @@ pipeline {
           expression { params.fmi_v1_12 }
         }
         steps {
-          test('maintenance/v1.12', 'v1.12-fmi', '', omsimulatorHash(), 'ripper2', 'LibraryTestingRipper2DB', true, '', true, false)
+          runRegressiontest('maintenance/v1.12', 'v1.12-fmi', '', omsimulatorHash(), 'ripper2', 'LibraryTestingRipper2DB', true, '', true, false)
         }
       }
       stage('v1.13 FMI') {
@@ -259,7 +259,7 @@ pipeline {
           expression { params.fmi_v1_13 }
         }
         steps {
-          test('maintenance/v1.13', 'v1.13-fmi', '', omsimulatorHash(), 'ripper2', 'LibraryTestingRipper2DB', true, '', true, false)
+          runRegressiontest('maintenance/v1.13', 'v1.13-fmi', '', omsimulatorHash(), 'ripper2', 'LibraryTestingRipper2DB', true, '', true, false)
         }
       }
       stage('v1.14 FMI') {
@@ -275,7 +275,7 @@ pipeline {
           expression { params.fmi_v1_14 }
         }
         steps {
-          test('maintenance/v1.14', 'v1.14-fmi', '', omsimulatorHash(), 'ripper2', 'LibraryTestingRipper2DB', false, '', true, false)
+          runRegressiontest('maintenance/v1.14', 'v1.14-fmi', '', omsimulatorHash(), 'ripper2', 'LibraryTestingRipper2DB', false, '', true, false)
         }
       }
       stage('v1.16 FMI') {
@@ -291,7 +291,7 @@ pipeline {
           expression { params.fmi_v1_16 }
         }
         steps {
-          test('maintenance/v1.16', 'v1.16-fmi', '', omsimulatorHash(), 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
+          runRegressiontest('maintenance/v1.16', 'v1.16-fmi', '', omsimulatorHash(), 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
         }
       }
       stage('v1.17 FMI') {
@@ -307,7 +307,7 @@ pipeline {
           expression { params.fmi_v1_17 }
         }
         steps {
-          test('maintenance/v1.17', 'v1.17-fmi', '', omsimulatorHash(), 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
+          runRegressiontest('maintenance/v1.17', 'v1.17-fmi', '', omsimulatorHash(), 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
         }
       }
       stage('v1.18 FMI') {
@@ -323,7 +323,7 @@ pipeline {
           expression { params.fmi_v1_18 }
         }
         steps {
-          test('maintenance/v1.18', 'v1.18-fmi', '', omsimulatorHash(), 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
+          runRegressiontest('maintenance/v1.18', 'v1.18-fmi', '', omsimulatorHash(), 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
         }
       }
       stage('v1.19 FMI') {
@@ -339,7 +339,7 @@ pipeline {
           expression { params.fmi_v1_19 }
         }
         steps {
-          test('maintenance/v1.19', 'v1.19-fmi', '', omsimulatorHash(), 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
+          runRegressiontest('maintenance/v1.19', 'v1.19-fmi', '', omsimulatorHash(), 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
         }
       }
       stage('v1.20 FMI') {
@@ -355,7 +355,7 @@ pipeline {
           expression { params.fmi_v1_20 }
         }
         steps {
-          test('maintenance/v1.20', 'v1.20-fmi', '', omsimulatorHash(), 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
+          runRegressiontest('maintenance/v1.20', 'v1.20-fmi', '', omsimulatorHash(), 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
         }
       }
       stage('master FMI') {
@@ -371,7 +371,7 @@ pipeline {
           expression { params.fmi_master }
         }
         steps {
-          test('master', 'master-fmi', '', 'origin/master', 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
+          runRegressiontest('master', 'master-fmi', '', 'origin/master', 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
         }
       }
       stage('newInst-daeMode') {
@@ -387,7 +387,7 @@ pipeline {
           expression { params.newInst_daeMode }
         }
         steps {
-          test('master', 'newInst-daeMode', 'setCommandLineOptions("-d=newInst,-frontEndUnitCheck --daeMode=true")', '', 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
+          runRegressiontest('master', 'newInst-daeMode', 'setCommandLineOptions("-d=newInst,-frontEndUnitCheck --daeMode=true")', '', 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
         }
       }
       stage('oldInst') {
@@ -403,7 +403,7 @@ pipeline {
           expression { params.oldInst }
         }
         steps {
-          test('master', 'oldInst', 'setCommandLineOptions("-d=nonewInst")', '', 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
+          runRegressiontest('master', 'oldInst', 'setCommandLineOptions("-d=nonewInst")', '', 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
         }
       }
       stage('cvode') {
@@ -419,7 +419,7 @@ pipeline {
           expression { params.cvode }
         }
         steps {
-          test('master', 'cvode', 'setCommandLineOptions("-d=newInst,-frontEndUnitCheck")', '', 'ripper2', 'LibraryTestingRipper2DB', false, '-s cvode', false, false)
+          runRegressiontest('master', 'cvode', 'setCommandLineOptions("-d=newInst,-frontEndUnitCheck")', '', 'ripper2', 'LibraryTestingRipper2DB', false, '-s cvode', false, false)
         }
       }
       stage('gbode') {
@@ -435,7 +435,7 @@ pipeline {
           expression { params.gbode }
         }
         steps {
-          test('master', 'gbode', 'setCommandLineOptions("-d=newInst,-frontEndUnitCheck")', '', 'ripper2', 'LibraryTestingRipper2DB', false, '-s gbode', false, false)
+          runRegressiontest('master', 'gbode', 'setCommandLineOptions("-d=newInst,-frontEndUnitCheck")', '', 'ripper2', 'LibraryTestingRipper2DB', false, '-s gbode', false, false)
         }
       }
       stage('generateSymbolicJacobian') {
@@ -451,7 +451,7 @@ pipeline {
           expression { params.generateSymbolicJacobian }
         }
         steps {
-          test('master', 'generateSymbolicJacobian', 'setCommandLineOptions("--generateSymbolicJacobian")', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
+          runRegressiontest('master', 'generateSymbolicJacobian', 'setCommandLineOptions("--generateSymbolicJacobian")', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
         }
       }
       stage('C++ v1.18') {
@@ -467,7 +467,7 @@ pipeline {
           expression { params.cpp_v1_18 }
         }
         steps {
-          test('maintenance/v1.18', 'v1.18-cpp', 'setCommandLineOptions("--simCodeTarget=Cpp")', '', 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
+          runRegressiontest('maintenance/v1.18', 'v1.18-cpp', 'setCommandLineOptions("--simCodeTarget=Cpp")', '', 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
         }
       }
       stage('C++ v1.19') {
@@ -483,7 +483,7 @@ pipeline {
           expression { params.cpp_v1_19 }
         }
         steps {
-          test('maintenance/v1.19', 'v1.19-cpp', 'setCommandLineOptions("--simCodeTarget=Cpp")', '', 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
+          runRegressiontest('maintenance/v1.19', 'v1.19-cpp', 'setCommandLineOptions("--simCodeTarget=Cpp")', '', 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
         }
       }
       stage('C++ v1.20') {
@@ -499,7 +499,7 @@ pipeline {
           expression { params.cpp_v1_20 }
         }
         steps {
-          test('maintenance/v1.20', 'v1.20-cpp', 'setCommandLineOptions("--simCodeTarget=Cpp")', '', 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
+          runRegressiontest('maintenance/v1.20', 'v1.20-cpp', 'setCommandLineOptions("--simCodeTarget=Cpp")', '', 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
         }
       }
       stage('C++') {
@@ -515,7 +515,7 @@ pipeline {
           expression { params.cpp }
         }
         steps {
-          test('master', 'cpp', 'setCommandLineOptions("--simCodeTarget=Cpp")', '', 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
+          runRegressiontest('master', 'cpp', 'setCommandLineOptions("--simCodeTarget=Cpp")', '', 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
         }
       }
     } }
@@ -719,7 +719,7 @@ def installLibraries(boolean removePackageOrder, boolean conversionScript, name,
     return "${env.HOME}/saved_omc/libraries"
   }
 }
-def test(branch, name, extraFlags, omsHash, dbPrefix, sshConfig, omcompiler, extrasimflags, boolean removePackageOrder, boolean conversionScript) {
+def runRegressiontest(branch, name, extraFlags, omsHash, dbPrefix, sshConfig, omcompiler, extrasimflags, boolean removePackageOrder, boolean conversionScript) {
   sh '''
   find /tmp  -name "*openmodelica.hudson*" -exec rm {} ";" || true
   mkdir -p ~/TEST_LIBS_BACKUP

--- a/.CI/Jenkinsfile
+++ b/.CI/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     booleanParam(name: 'v1_17', defaultValue: false, description: 'maintenance/v1.17 branch (ryzen-5950x-1)')
     booleanParam(name: 'v1_18', defaultValue: false, description: 'maintenance/v1.18 branch (ryzen-5950x-1)')
     booleanParam(name: 'v1_19', defaultValue: false, description: 'maintenance/v1.19 branch (ryzen-5950x-1)')
-    booleanParam(name: 'v1_20', defaultValue: false, description: 'maintenance/v1.20 branch (ryzen-5950x-1)')    
+    booleanParam(name: 'v1_20', defaultValue: false, description: 'maintenance/v1.20 branch (ryzen-5950x-1)')
     booleanParam(name: 'master', defaultValue: false, description: 'master branch (ryzen-5950x-1)')
 
     booleanParam(name: 'fmi_v1_12', defaultValue: false, description: 'maintenance/v1.12 branch with FMI (ryzen-5950x-2)')
@@ -144,7 +144,7 @@ pipeline {
           test('maintenance/v1.18', 'v1.18', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
         }
       }
-      
+
       stage('v1.19') {
         agent {
           node {
@@ -641,7 +641,7 @@ pipeline {
 
           sh "./report.py --branches='cvode' configs/conf.json"
           sh "mv overview.html overview-cvode.html"
-          
+
           sh "./report.py --branches='gbode' configs/conf.json"
           sh "mv overview.html overview-gbode.html"
 
@@ -879,9 +879,9 @@ def test(branch, name, extraFlags, omsHash, dbPrefix, sshConfig, omcompiler, ext
 
   mkdir -p "/var/www/libraries.openmodelica.org/branches/${name}/"
   """
-  
+
   def libraryPath = installLibraries(removePackageOrder, conversionScript, name, "${WORKSPACE}/OpenModelica/${OMCPATH}/build")
-  
+
   sh "test -d '${libraryPath}/.openmodelica/libraries/Modelica trunk'"
 
   sh """

--- a/.CI/Jenkinsfile
+++ b/.CI/Jenkinsfile
@@ -719,7 +719,14 @@ def installLibraries(boolean removePackageOrder, boolean conversionScript, name,
     return "${env.HOME}/saved_omc/libraries"
   }
 }
-def runRegressiontest(branch, name, extraFlags, omsHash, dbPrefix, sshConfig, omcompiler, extrasimflags, boolean removePackageOrder, boolean conversionScript) {
+
+/**
+  * Launches the test.py script with the given options.
+  *
+  * @param jobs: The number of tests/jobs to launch in parallel.
+                 By default this is set to 0 which means launch as many tests as there are available physical cpus on the machine'.
+  */
+def runRegressiontest(branch, name, extraFlags, omsHash, dbPrefix, sshConfig, omcompiler, extrasimflags, boolean removePackageOrder, boolean conversionScript, int jobs=0) {
   sh '''
   find /tmp  -name "*openmodelica.hudson*" -exec rm {} ";" || true
   mkdir -p ~/TEST_LIBS_BACKUP
@@ -906,7 +913,7 @@ def runRegressiontest(branch, name, extraFlags, omsHash, dbPrefix, sshConfig, om
   export HOME="${libraryPath}"
   cd OpenModelicaLibraryTesting
   # Force /usr/bin/omc as being used for generating the mos-files. Ensures consistent behavior among all tested OMC versions
-  stdbuf -oL -eL time ./test.py --ompython_omhome=/usr ${FMI_TESTING_FLAG} --extraflags='${extraFlags}' --extrasimflags='${extrasimflags}' --branch="${name}" --output="libraries.openmodelica.org:/var/www/libraries.openmodelica.org/branches/${name}/" --libraries='${libraryPath}/.openmodelica/libraries/' configs/conf.json ${params.OLDLIBS ? "configs/conf-old.json configs/conf-nonstandard.json" : ""} || (killall omc ; false) || exit 1
+  stdbuf -oL -eL time ./test.py --ompython_omhome=/usr ${FMI_TESTING_FLAG} --extraflags='${extraFlags}' --extrasimflags='${extrasimflags}' --branch="${name}" --output="libraries.openmodelica.org:/var/www/libraries.openmodelica.org/branches/${name}/" --libraries='${libraryPath}/.openmodelica/libraries/' --jobs=${jobs} configs/conf.json ${params.OLDLIBS ? "configs/conf-old.json configs/conf-nonstandard.json" : ""} || (killall omc ; false) || exit 1
   """
   sh 'date'
   sh "rm -f OpenModelicaLibraryTesting/${dbPrefix}-sqlite3.db.tmp"

--- a/test.py
+++ b/test.py
@@ -118,12 +118,20 @@ docker = args.docker
 librariespath = args.libraries
 overrideDefaults = [arg.split("=", 1) for arg in args.default]
 
+
 # If -j=0 is specified (or -j is not specified, defaults to 0) then use all available physical CPUS.
 if n_jobs == 0:
   n_jobs = psutil.cpu_count(logical=False)
 
-print("branch: %s, n_jobs: %d" % (branch, n_jobs))
+# If we are running one test at a time assume that omc is allowed to use multiple
+# threads for each individual test.
+if n_jobs == 1:
+  single_thread="" # Alternative: single_thread="-n=0"
+else:
+  single_thread="-n=1"
 
+
+print("branch: %s, n_jobs: %d" % (branch, n_jobs))
 
 if clean:
   print("Removing temporary files, etc to the best ability of the script")
@@ -160,7 +168,6 @@ if configs == []:
 from OMPython import OMCSession, OMCSessionZMQ
 
 version_cmd = "--version"
-single_thread="-n=1"
 
 # Try to make the processes a bit nicer...
 os.environ["GC_MARKERS"]="1"
@@ -196,7 +203,6 @@ sys.stdout.flush()
 # Do feature checks. Handle things like old RML-style arguments...
 
 subprocess.check_output(omc_cmd + ["-n=1", version_cmd], stderr=subprocess.STDOUT).strip()
-single_thread="-n=1"
 
 sys.stdout.flush()
 

--- a/test.py
+++ b/test.py
@@ -100,13 +100,13 @@ parser.add_argument('--noclean', action="store_true", default=False)
 parser.add_argument('--fmisimulator', default='')
 parser.add_argument('--ulimitvmem', help="Virtual memory limit (in kB)", type=int, default=8*1024*1024)
 parser.add_argument('--default', action='append', help="Add a default value for some configuration key, such as --default=ulimitExe=60. The equals sign is mandatory.", default=[])
-parser.add_argument('-n', default=psutil.cpu_count(logical=False))
+parser.add_argument('-j', '--jobs', default=0)
 
 args = parser.parse_args()
 configs = args.configs
 branch = args.branch
 result_location = args.output
-n_jobs = int(args.n)
+n_jobs = int(args.jobs)
 clean = not args.noclean
 extraflags = args.extraflags
 extrasimflags = args.extrasimflags
@@ -117,7 +117,14 @@ ulimitMemory = args.ulimitvmem
 docker = args.docker
 librariespath = args.libraries
 overrideDefaults = [arg.split("=", 1) for arg in args.default]
+
+# If -j=0 is specified (or -j is not specified, defaults to 0) then use all available physical CPUS.
+if n_jobs == 0:
+  n_jobs = psutil.cpu_count(logical=False)
+
 print("branch: %s, n_jobs: %d" % (branch, n_jobs))
+
+
 if clean:
   print("Removing temporary files, etc to the best ability of the script")
 
@@ -474,12 +481,12 @@ for (library,conf) in configs:
   if not (omc.sendExpression('setCommandLineOptions("-g=MetaModelica")') or omc.sendExpression('setCommandLineOptions("+g=Modelica")')):
     print("Failed to set MetaModelica grammar")
     sys.exit(1)
-  
+
   try:
     conf["resourceLocation"]=omc.sendExpression('uriToFilename("modelica://%s/Resources")' % library)
   except:
     conf["resourceLocation"]=""
-  
+
   if "runOnceBeforeTesting" in conf:
     for cmd in conf["runOnceBeforeTesting"]:
       # replace the resource location in the command if present


### PR DESCRIPTION
[Trim whitespace.](https://github.com/OpenModelica/OpenModelicaLibraryTesting/commit/4bc0ed0408d6fb21e1c4b4a8f268b8374857aa9c)



[Rename function for clarity.](https://github.com/OpenModelica/OpenModelicaLibraryTesting/commit/df5802dea999dd08426d56882e576c0c1d0bceb0) 

  - Rename `test()` to `runRegressionTest()`. `test` is too generic and difficult
    to notice.
 
[Rename option to 'j' instead of 'n'.](https://github.com/OpenModelica/OpenModelicaLibraryTesting/commit/3ae9b8ef7c4b46d55b41518b8fd5ab98a04fab5d) 

  - `-n` is used by OpenModelica itself to control its own number of threads.
  - Use `-j (--jobs)` for the python script instead to avoid confusion.


[Allow specifying the number of jobs for regression testing.](https://github.com/OpenModelica/OpenModelicaLibraryTesting/commit/43bd40c1e94c83d3bb8609824d1ecc2c48d98520) 

  - Add a new parameter `jobs` to the `runRegressiontest` function. By
    default this is set to 0. This will be passed to the `test.py` script
    which will use it to determine the number of jobs to use for running
    tests.
 
[If running on test at a time allow `omc` multithreading.](https://github.com/OpenModelica/OpenModelicaLibraryTesting/commit/543e59365340fd062a42748a581c82ee4496a13e) 

  - If tests jobs are done one at a time, i.e. `--jobs=1` is set for the
    python test script, assume that we are allowed to use multiple threads
    for each test itself. That is, allow `omc `to run single tests with its
    own multiple threads when needed.

  - This should ideally be its own flag/option passed to the test script.
    However, with the current requirements it is an overkill.
 
[Add a new job 'heavy_tests'.](https://github.com/OpenModelica/OpenModelicaLibraryTesting/commit/592ab6476badfe653346c45dc9cfdec8662b3deb) 

  - This job will run test one at a time. That is, it will not launch
    multiple tests at once.

    However, for each individual test, `omc` should be allowed to use multiple
    threads (e.g. to load libraries, generate and compile C code).

  - The job is intended to be manually started (no schedule for now).

  - The name of the job is preliminary and can be changed.


