### PR TITLE
Config file select

### DIFF
--- a/.CI/Jenkinsfile
+++ b/.CI/Jenkinsfile
@@ -57,7 +57,18 @@ pipeline {
           expression { params.v1_12 }
         }
         steps {
-          runRegressiontest('maintenance/v1.12', 'v1.12', '', '', 'ripper1', 'LibraryTestingRipper1DB', true, '', true, false)
+          runRegressiontest(branch: 'maintenance/v1.12',
+                            name: 'v1.12',
+                            extraFlags: '',
+                            omsHash: '',
+                            dbPrefix: 'ripper1',
+                            sshConfig: 'LibraryTestingRipper1DB',
+                            omcompiler: true,
+                            extrasimflags: '',
+                            removePackageOrder: true,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
 
@@ -74,7 +85,18 @@ pipeline {
           expression { params.v1_13 }
         }
         steps {
-          runRegressiontest('maintenance/v1.13', 'v1.13', '', '', 'ripper1', 'LibraryTestingRipper1DB', true, '', true, false)
+          runRegressiontest(branch: 'maintenance/v1.13',
+                            name: 'v1.13',
+                            extraFlags: '',
+                            omsHash: '',
+                            dbPrefix: 'ripper1',
+                            sshConfig: 'LibraryTestingRipper1DB',
+                            omcompiler: true,
+                            extrasimflags: '',
+                            removePackageOrder: true,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
 
@@ -91,7 +113,18 @@ pipeline {
           expression { params.v1_14 }
         }
         steps {
-          runRegressiontest('maintenance/v1.14', 'v1.14', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', true, false)
+          runRegressiontest(branch: 'maintenance/v1.14',
+                            name: 'v1.14',
+                            extraFlags: '',
+                            omsHash: '',
+                            dbPrefix: 'ripper1',
+                            sshConfig: 'LibraryTestingRipper1DB',
+                            omcompiler: false,
+                            extrasimflags: '',
+                            removePackageOrder: true,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
 
@@ -108,7 +141,18 @@ pipeline {
           expression { params.v1_16 }
         }
         steps {
-          runRegressiontest('maintenance/v1.16', 'v1.16', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
+          runRegressiontest(branch: 'maintenance/v1.16',
+                            name: 'v1.16',
+                            extraFlags: '',
+                            omsHash: '',
+                            dbPrefix: 'ripper1',
+                            sshConfig: 'LibraryTestingRipper1DB',
+                            omcompiler: false,
+                            extrasimflags: '',
+                            removePackageOrder: false,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
 
@@ -125,7 +169,18 @@ pipeline {
           expression { params.v1_17 }
         }
         steps {
-          runRegressiontest('maintenance/v1.17', 'v1.17', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
+          runRegressiontest(branch: 'maintenance/v1.17',
+                            name: 'v1.17',
+                            extraFlags: '',
+                            omsHash: '',
+                            dbPrefix: 'ripper1',
+                            sshConfig: 'LibraryTestingRipper1DB',
+                            omcompiler: false,
+                            extrasimflags: '',
+                            removePackageOrder: false,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
 
@@ -142,7 +197,18 @@ pipeline {
           expression { params.v1_18 }
         }
         steps {
-          runRegressiontest('maintenance/v1.18', 'v1.18', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
+          runRegressiontest(branch: 'maintenance/v1.18',
+                            name: 'v1.18',
+                            extraFlags: '',
+                            omsHash: '',
+                            dbPrefix: 'ripper1',
+                            sshConfig: 'LibraryTestingRipper1DB',
+                            omcompiler: false,
+                            extrasimflags: '',
+                            removePackageOrder: false,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
 
@@ -159,7 +225,18 @@ pipeline {
           expression { params.v1_19 }
         }
         steps {
-          runRegressiontest('maintenance/v1.19', 'v1.19', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
+          runRegressiontest(branch: 'maintenance/v1.19',
+                            name: 'v1.19',
+                            extraFlags: '',
+                            omsHash: '',
+                            dbPrefix: 'ripper1',
+                            sshConfig: 'LibraryTestingRipper1DB',
+                            omcompiler: false,
+                            extrasimflags: '',
+                            removePackageOrder: false,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
 
@@ -176,7 +253,18 @@ pipeline {
           expression { params.v1_20 }
         }
         steps {
-          runRegressiontest('maintenance/v1.20', 'v1.20', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
+          runRegressiontest(branch: 'maintenance/v1.20',
+                            name: 'v1.20',
+                            extraFlags: '',
+                            omsHash: '',
+                            dbPrefix: 'ripper1',
+                            sshConfig: 'LibraryTestingRipper1DB',
+                            omcompiler: false,
+                            extrasimflags: '',
+                            removePackageOrder: false,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
 
@@ -193,7 +281,18 @@ pipeline {
           expression { params.master }
         }
         steps {
-          runRegressiontest('master', 'master', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
+          runRegressiontest(branch: 'master',
+                            name: 'master',
+                            extraFlags: '',
+                            omsHash: '',
+                            dbPrefix: 'ripper1',
+                            sshConfig: 'LibraryTestingRipper1DB',
+                            omcompiler: false,
+                            extrasimflags: '',
+                            removePackageOrder: false,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
 
@@ -210,7 +309,18 @@ pipeline {
           expression { params.conversion_script }
         }
         steps {
-          runRegressiontest('master', 'conversion', '', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, true)
+          runRegressiontest(branch: 'master',
+                            name: 'conversion',
+                            extraFlags: '',
+                            omsHash: '',
+                            dbPrefix: 'ripper1',
+                            sshConfig: 'LibraryTestingRipper1DB',
+                            omcompiler: false,
+                            extrasimflags: '',
+                            removePackageOrder: false,
+                            conversionScript: true,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
 
@@ -227,7 +337,18 @@ pipeline {
           expression { params.newInst_newBackend }
         }
         steps {
-          runRegressiontest('master', 'newInst-newBackend', 'setCommandLineOptions("-d=newInst,-frontEndUnitCheck --newBackend")', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
+          runRegressiontest(branch: 'master',
+                            name: 'newInst-newBackend',
+                            extraFlags: 'setCommandLineOptions("-d=newInst,-frontEndUnitCheck --newBackend")',
+                            omsHash: '',
+                            dbPrefix: 'ripper1',
+                            sshConfig: 'LibraryTestingRipper1DB',
+                            omcompiler: false,
+                            extrasimflags: '',
+                            removePackageOrder: false,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
 
@@ -244,7 +365,18 @@ pipeline {
           expression { params.fmi_v1_12 }
         }
         steps {
-          runRegressiontest('maintenance/v1.12', 'v1.12-fmi', '', omsimulatorHash(), 'ripper2', 'LibraryTestingRipper2DB', true, '', true, false)
+          runRegressiontest(branch: 'maintenance/v1.12',
+                            name: 'v1.12-fmi',
+                            extraFlags: '',
+                            omsHash: omsimulatorHash(),
+                            dbPrefix: 'ripper2',
+                            sshConfig: 'LibraryTestingRipper2DB',
+                            omcompiler: true,
+                            extrasimflags: '',
+                            removePackageOrder: true,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
       stage('v1.13 FMI') {
@@ -260,7 +392,18 @@ pipeline {
           expression { params.fmi_v1_13 }
         }
         steps {
-          runRegressiontest('maintenance/v1.13', 'v1.13-fmi', '', omsimulatorHash(), 'ripper2', 'LibraryTestingRipper2DB', true, '', true, false)
+          runRegressiontest(branch: 'maintenance/v1.13',
+                            name: 'v1.13-fmi',
+                            extraFlags: '',
+                            omsHash: omsimulatorHash(),
+                            dbPrefix: 'ripper2',
+                            sshConfig: 'LibraryTestingRipper2DB',
+                            omcompiler: true,
+                            extrasimflags: '',
+                            removePackageOrder: true,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
       stage('v1.14 FMI') {
@@ -276,7 +419,18 @@ pipeline {
           expression { params.fmi_v1_14 }
         }
         steps {
-          runRegressiontest('maintenance/v1.14', 'v1.14-fmi', '', omsimulatorHash(), 'ripper2', 'LibraryTestingRipper2DB', false, '', true, false)
+          runRegressiontest(branch: 'maintenance/v1.14',
+                            name: 'v1.14-fmi',
+                            extraFlags: '',
+                            omsHash: omsimulatorHash(),
+                            dbPrefix: 'ripper2',
+                            sshConfig: 'LibraryTestingRipper2DB',
+                            omcompiler: false,
+                            extrasimflags: '',
+                            removePackageOrder: true,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
       stage('v1.16 FMI') {
@@ -292,7 +446,18 @@ pipeline {
           expression { params.fmi_v1_16 }
         }
         steps {
-          runRegressiontest('maintenance/v1.16', 'v1.16-fmi', '', omsimulatorHash(), 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
+          runRegressiontest(branch: 'maintenance/v1.16',
+                            name: 'v1.16-fmi',
+                            extraFlags: '',
+                            omsHash: omsimulatorHash(),
+                            dbPrefix: 'ripper2',
+                            sshConfig: 'LibraryTestingRipper2DB',
+                            omcompiler: false,
+                            extrasimflags: '',
+                            removePackageOrder: false,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
       stage('v1.17 FMI') {
@@ -308,7 +473,18 @@ pipeline {
           expression { params.fmi_v1_17 }
         }
         steps {
-          runRegressiontest('maintenance/v1.17', 'v1.17-fmi', '', omsimulatorHash(), 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
+          runRegressiontest(branch: 'maintenance/v1.17',
+                            name: 'v1.17-fmi',
+                            extraFlags: '',
+                            omsHash: omsimulatorHash(),
+                            dbPrefix: 'ripper2',
+                            sshConfig: 'LibraryTestingRipper2DB',
+                            omcompiler: false,
+                            extrasimflags: '',
+                            removePackageOrder: false,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
       stage('v1.18 FMI') {
@@ -324,7 +500,18 @@ pipeline {
           expression { params.fmi_v1_18 }
         }
         steps {
-          runRegressiontest('maintenance/v1.18', 'v1.18-fmi', '', omsimulatorHash(), 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
+          runRegressiontest(branch: 'maintenance/v1.18',
+                            name: 'v1.18-fmi',
+                            extraFlags: '',
+                            omsHash: omsimulatorHash(),
+                            dbPrefix: 'ripper2',
+                            sshConfig: 'LibraryTestingRipper2DB',
+                            omcompiler: false,
+                            extrasimflags: '',
+                            removePackageOrder: false,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
       stage('v1.19 FMI') {
@@ -340,7 +527,18 @@ pipeline {
           expression { params.fmi_v1_19 }
         }
         steps {
-          runRegressiontest('maintenance/v1.19', 'v1.19-fmi', '', omsimulatorHash(), 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
+          runRegressiontest(branch: 'maintenance/v1.19',
+                            name: 'v1.19-fmi',
+                            extraFlags: '',
+                            omsHash: omsimulatorHash(),
+                            dbPrefix: 'ripper2',
+                            sshConfig: 'LibraryTestingRipper2DB',
+                            omcompiler: false,
+                            extrasimflags: '',
+                            removePackageOrder: false,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
       stage('v1.20 FMI') {
@@ -356,7 +554,18 @@ pipeline {
           expression { params.fmi_v1_20 }
         }
         steps {
-          runRegressiontest('maintenance/v1.20', 'v1.20-fmi', '', omsimulatorHash(), 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
+          runRegressiontest(branch: 'maintenance/v1.20',
+                            name: 'v1.20-fmi',
+                            extraFlags: '',
+                            omsHash: omsimulatorHash(),
+                            dbPrefix: 'ripper2',
+                            sshConfig: 'LibraryTestingRipper2DB',
+                            omcompiler: false,
+                            extrasimflags: '',
+                            removePackageOrder: false,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
       stage('master FMI') {
@@ -372,7 +581,18 @@ pipeline {
           expression { params.fmi_master }
         }
         steps {
-          runRegressiontest('master', 'master-fmi', '', 'origin/master', 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
+          runRegressiontest(branch: 'master',
+                            name: 'master-fmi',
+                            extraFlags: '',
+                            omsHash: 'origin/master',
+                            dbPrefix: 'ripper2',
+                            sshConfig: 'LibraryTestingRipper2DB',
+                            omcompiler: false,
+                            extrasimflags: '',
+                            removePackageOrder: false,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
       stage('newInst-daeMode') {
@@ -388,7 +608,18 @@ pipeline {
           expression { params.newInst_daeMode }
         }
         steps {
-          runRegressiontest('master', 'newInst-daeMode', 'setCommandLineOptions("-d=newInst,-frontEndUnitCheck --daeMode=true")', '', 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
+          runRegressiontest(branch: 'master',
+                            name: 'newInst-daeMode',
+                            extraFlags: 'setCommandLineOptions("-d=newInst,-frontEndUnitCheck --daeMode=true")',
+                            omsHash: '',
+                            dbPrefix: 'ripper2',
+                            sshConfig: 'LibraryTestingRipper2DB',
+                            omcompiler: false,
+                            extrasimflags: '',
+                            removePackageOrder: false,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
       stage('oldInst') {
@@ -404,7 +635,18 @@ pipeline {
           expression { params.oldInst }
         }
         steps {
-          runRegressiontest('master', 'oldInst', 'setCommandLineOptions("-d=nonewInst")', '', 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
+          runRegressiontest(branch: 'master',
+                            name: 'oldInst',
+                            extraFlags: 'setCommandLineOptions("-d=nonewInst")',
+                            omsHash: '',
+                            dbPrefix: 'ripper2',
+                            sshConfig: 'LibraryTestingRipper2DB',
+                            omcompiler: false,
+                            extrasimflags: '',
+                            removePackageOrder: false,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
       stage('cvode') {
@@ -420,7 +662,18 @@ pipeline {
           expression { params.cvode }
         }
         steps {
-          runRegressiontest('master', 'cvode', 'setCommandLineOptions("-d=newInst,-frontEndUnitCheck")', '', 'ripper2', 'LibraryTestingRipper2DB', false, '-s cvode', false, false)
+          runRegressiontest(branch: 'master',
+                            name: 'cvode',
+                            extraFlags: 'setCommandLineOptions("-d=newInst,-frontEndUnitCheck")',
+                            omsHash: '',
+                            dbPrefix: 'ripper2',
+                            sshConfig: 'LibraryTestingRipper2DB',
+                            omcompiler: false,
+                            extrasimflags: '-s cvode',
+                            removePackageOrder: false,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
       stage('gbode') {
@@ -436,7 +689,18 @@ pipeline {
           expression { params.gbode }
         }
         steps {
-          runRegressiontest('master', 'gbode', 'setCommandLineOptions("-d=newInst,-frontEndUnitCheck")', '', 'ripper2', 'LibraryTestingRipper2DB', false, '-s gbode', false, false)
+          runRegressiontest(branch: 'master',
+                            name: 'gbode',
+                            extraFlags: 'setCommandLineOptions("-d=newInst,-frontEndUnitCheck")',
+                            omsHash: '',
+                            dbPrefix: 'ripper2',
+                            sshConfig: 'LibraryTestingRipper2DB',
+                            omcompiler: false,
+                            extrasimflags: '-s gbode',
+                            removePackageOrder: false,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
       stage('generateSymbolicJacobian') {
@@ -452,7 +716,18 @@ pipeline {
           expression { params.generateSymbolicJacobian }
         }
         steps {
-          runRegressiontest('master', 'generateSymbolicJacobian', 'setCommandLineOptions("--generateSymbolicJacobian")', '', 'ripper1', 'LibraryTestingRipper1DB', false, '', false, false)
+          runRegressiontest(branch: 'master',
+                            name: 'generateSymbolicJacobian',
+                            extraFlags: 'setCommandLineOptions("--generateSymbolicJacobian")',
+                            omsHash: '',
+                            dbPrefix: 'ripper1',
+                            sshConfig: 'LibraryTestingRipper1DB',
+                            omcompiler: false,
+                            extrasimflags: '',
+                            removePackageOrder: false,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
       stage('heavy_tests') {
@@ -468,18 +743,18 @@ pipeline {
           expression { params.heavy_tests }
         }
         steps {
-            runRegressiontest(branch: 'master',
-                              name: 'heavy_tests',
-                              extraFlags: '',
-                              omsHash: '',
-                              dbPrefix: 'ripper2',
-                              sshConfig: 'LibraryTestingRipper2DB',
-                              omcompiler: false,
-                              extrasimflags: '',
-                              removePackageOrder: false,
-                              conversionScript: false,
-                              libs_config_file: 'configs/conf.json',
-                              jobs: 1)
+          runRegressiontest(branch: 'master',
+                            name: 'heavy_tests',
+                            extraFlags: '',
+                            omsHash: '',
+                            dbPrefix: 'ripper2',
+                            sshConfig: 'LibraryTestingRipper2DB',
+                            omcompiler: false,
+                            extrasimflags: '',
+                            removePackageOrder: false,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 1)
         }
       }
       stage('C++ v1.18') {
@@ -495,7 +770,18 @@ pipeline {
           expression { params.cpp_v1_18 }
         }
         steps {
-          runRegressiontest('maintenance/v1.18', 'v1.18-cpp', 'setCommandLineOptions("--simCodeTarget=Cpp")', '', 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
+          runRegressiontest(branch: 'maintenance/v1.18',
+                            name: 'v1.18-cpp',
+                            extraFlags: 'setCommandLineOptions("--simCodeTarget=Cpp")',
+                            omsHash: '',
+                            dbPrefix: 'ripper2',
+                            sshConfig: 'LibraryTestingRipper2DB',
+                            omcompiler: false,
+                            extrasimflags: '',
+                            removePackageOrder: false,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
       stage('C++ v1.19') {
@@ -511,7 +797,18 @@ pipeline {
           expression { params.cpp_v1_19 }
         }
         steps {
-          runRegressiontest('maintenance/v1.19', 'v1.19-cpp', 'setCommandLineOptions("--simCodeTarget=Cpp")', '', 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
+          runRegressiontest(branch: 'maintenance/v1.19',
+                            name: 'v1.19-cpp',
+                            extraFlags: 'setCommandLineOptions("--simCodeTarget=Cpp")',
+                            omsHash: '',
+                            dbPrefix: 'ripper2',
+                            sshConfig: 'LibraryTestingRipper2DB',
+                            omcompiler: false,
+                            extrasimflags: '',
+                            removePackageOrder: false,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
       stage('C++ v1.20') {
@@ -527,7 +824,18 @@ pipeline {
           expression { params.cpp_v1_20 }
         }
         steps {
-          runRegressiontest('maintenance/v1.20', 'v1.20-cpp', 'setCommandLineOptions("--simCodeTarget=Cpp")', '', 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
+          runRegressiontest(branch: 'maintenance/v1.20',
+                            name: 'v1.20-cpp',
+                            extraFlags: 'setCommandLineOptions("--simCodeTarget=Cpp")',
+                            omsHash: '',
+                            dbPrefix: 'ripper2',
+                            sshConfig: 'LibraryTestingRipper2DB',
+                            omcompiler: false,
+                            extrasimflags: '',
+                            removePackageOrder: false,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
       stage('C++') {
@@ -543,7 +851,18 @@ pipeline {
           expression { params.cpp }
         }
         steps {
-          runRegressiontest('master', 'cpp', 'setCommandLineOptions("--simCodeTarget=Cpp")', '', 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false)
+          runRegressiontest(branch: 'master',
+                            name: 'cpp',
+                            extraFlags: 'setCommandLineOptions("--simCodeTarget=Cpp")',
+                            omsHash: '',
+                            dbPrefix: 'ripper2',
+                            sshConfig: 'LibraryTestingRipper2DB',
+                            omcompiler: false,
+                            extrasimflags: '',
+                            removePackageOrder: false,
+                            conversionScript: false,
+                            libs_config_file: 'configs/conf.json',
+                            jobs: 0)
         }
       }
     } }
@@ -754,6 +1073,7 @@ def installLibraries(boolean removePackageOrder, boolean conversionScript, name,
 /**
   * Launches the test.py script with the given options.
   *
+  * @param libs_config_file: The config file to be used for testing. This file specifies which libraries to test and what options to use for them.
   * @param jobs: The number of tests/jobs to launch in parallel.
                  By default this is set to 0 which means launch as many tests as there are available physical cpus on the machine'.
   */

--- a/.CI/Jenkinsfile
+++ b/.CI/Jenkinsfile
@@ -468,7 +468,18 @@ pipeline {
           expression { params.heavy_tests }
         }
         steps {
-          runRegressiontest('master', 'heavy_tests', '', '', 'ripper2', 'LibraryTestingRipper2DB', false, '', false, false, 1)
+            runRegressiontest(branch: 'master',
+                              name: 'heavy_tests',
+                              extraFlags: '',
+                              omsHash: '',
+                              dbPrefix: 'ripper2',
+                              sshConfig: 'LibraryTestingRipper2DB',
+                              omcompiler: false,
+                              extrasimflags: '',
+                              removePackageOrder: false,
+                              conversionScript: false,
+                              libs_config_file: 'configs/conf.json',
+                              jobs: 1)
         }
       }
       stage('C++ v1.18') {
@@ -746,7 +757,7 @@ def installLibraries(boolean removePackageOrder, boolean conversionScript, name,
   * @param jobs: The number of tests/jobs to launch in parallel.
                  By default this is set to 0 which means launch as many tests as there are available physical cpus on the machine'.
   */
-def runRegressiontest(branch, name, extraFlags, omsHash, dbPrefix, sshConfig, omcompiler, extrasimflags, boolean removePackageOrder, boolean conversionScript, int jobs=0) {
+def runRegressiontest(branch, name, extraFlags, omsHash, dbPrefix, sshConfig, omcompiler, extrasimflags, boolean removePackageOrder, boolean conversionScript, String libs_config_file = 'configs/conf.json', int jobs=0) {
   sh '''
   find /tmp  -name "*openmodelica.hudson*" -exec rm {} ";" || true
   mkdir -p ~/TEST_LIBS_BACKUP
@@ -933,7 +944,7 @@ def runRegressiontest(branch, name, extraFlags, omsHash, dbPrefix, sshConfig, om
   export HOME="${libraryPath}"
   cd OpenModelicaLibraryTesting
   # Force /usr/bin/omc as being used for generating the mos-files. Ensures consistent behavior among all tested OMC versions
-  stdbuf -oL -eL time ./test.py --ompython_omhome=/usr ${FMI_TESTING_FLAG} --extraflags='${extraFlags}' --extrasimflags='${extrasimflags}' --branch="${name}" --output="libraries.openmodelica.org:/var/www/libraries.openmodelica.org/branches/${name}/" --libraries='${libraryPath}/.openmodelica/libraries/' --jobs=${jobs} configs/conf.json ${params.OLDLIBS ? "configs/conf-old.json configs/conf-nonstandard.json" : ""} || (killall omc ; false) || exit 1
+  stdbuf -oL -eL time ./test.py --ompython_omhome=/usr ${FMI_TESTING_FLAG} --extraflags='${extraFlags}' --extrasimflags='${extrasimflags}' --branch="${name}" --output="libraries.openmodelica.org:/var/www/libraries.openmodelica.org/branches/${name}/" --libraries='${libraryPath}/.openmodelica/libraries/' --jobs=${jobs} ${libs_config_file} ${params.OLDLIBS ? "configs/conf-old.json configs/conf-nonstandard.json" : ""} || (killall omc ; false) || exit 1
   """
   sh 'date'
   sh "rm -f OpenModelicaLibraryTesting/${dbPrefix}-sqlite3.db.tmp"


### PR DESCRIPTION
[Allow selection of config file.](https://github.com/OpenModelica/OpenModelicaLibraryTesting/commit/c30d0b76088a3a93cf5494e5652768d16c76780a) 

  - runRegressionTest() now takes one more parameter specifying which
    config file to use. By default this is set to 'configs/conf.json'.

    All testing jobs use the default value right now. It will, at least,
    be changed for the `heavey_tests` job once the appropriate config
    file is added.

 
[Refactor and reformat.](https://github.com/OpenModelica/OpenModelicaLibraryTesting/commit/3017c471a40a2585cefdb792217483270976fa18) 

  - Just for readability.