### PR TITLE
Specify branch and directory for github reference files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,13 @@
 __pycache__
 !HelloWorld.mo
 !HelloWorld.mos
+/*.files
+/*.html
 /*.json
 /converted-libraries
+/PNlib*/
+/ReferenceFiles/
 files/
 HelloWorld*
 history/
 sqlite3.db
-/*.html
-/*.files

--- a/configs/sanityCheck.json
+++ b/configs/sanityCheck.json
@@ -8,7 +8,7 @@
       "giturl":"https://github.com/AMIT-HSBI/PNlib",
       "destination":"ReferenceFiles/PNlib",
       "git-ref": "v2.2",
-      "directory": "ReferenceFiles"
+      "git-directory": "ReferenceFiles"
     }
   }
 ]

--- a/configs/sanityCheck.json
+++ b/configs/sanityCheck.json
@@ -1,6 +1,14 @@
 [
   {
     "library": "PNlib",
-    "libraryVersion": "2.2.0"
+    "libraryVersion": "2.2.0",
+    "referenceFileExtension":"mat",
+    "referenceFileNameDelimiter":".",
+    "referenceFiles":{
+      "giturl":"https://github.com/AMIT-HSBI/PNlib",
+      "destination":"ReferenceFiles/PNlib",
+      "git-ref": "v2.2",
+      "directory": "ReferenceFiles"
+    }
   }
 ]

--- a/test.py
+++ b/test.py
@@ -345,6 +345,9 @@ for (lib,c) in configs:
           raise Exception("Environment variable %s not defined, but used in JSON config for reference files" % k)
         c["referenceFiles"] = c["referenceFiles"].replace(m.group(0), os.environ[k])
     elif "giturl" in c["referenceFiles"]:
+      refFilesGitTag = "origin/master"
+      if "git-ref" in c["referenceFiles"]:
+        refFilesGitTag = c["referenceFiles"]["git-ref"].strip()
       if c["referenceFiles"]["destination"] in preparedReferenceDirs:
         (c["referenceFiles"],c["referenceFilesURL"]) = preparedReferenceDirs[destination]
         continue

--- a/test.py
+++ b/test.py
@@ -375,7 +375,13 @@ for (lib,c) in configs:
       subprocess.check_call(["git", "clean", "-fdx", "--exclude=*.hash"], stderr=subprocess.STDOUT, cwd=destinationReal)
       subprocess.check_call(["find", ".", "-name", "*.mat.xz", "-exec", "xz", "--decompress", "--keep", "{}", ";"], stderr=subprocess.STDOUT, cwd=destinationReal)
       githash = subprocess.check_output(["git", "rev-parse", "--verify", "HEAD"], stderr=subprocess.STDOUT, cwd=destinationReal, encoding='utf8')
-      c["referenceFiles"] = destinationReal
+
+      if "git-directory" in c["referenceFiles"]:
+        c["referenceFiles"] = os.path.join(destinationReal, c["referenceFiles"]['git-directory'])
+        print(c["referenceFiles"])
+      else:
+        c["referenceFiles"] = destinationReal
+
       if giturl.startswith("https://github.com"):
         c["referenceFilesURL"] = '<a href="%s/tree/%s">%s (%s)</a>' % (giturl, githash.strip(), giturl,githash.strip())
       else:

--- a/test.py
+++ b/test.py
@@ -358,7 +358,7 @@ for (lib,c) in configs:
       destinationReal = os.path.realpath(destination)
       subprocess.check_call(["git", "clean", "-fdx", "--exclude=*.hash"], stderr=subprocess.STDOUT, cwd=destinationReal)
       subprocess.check_call(["git", "fetch", "origin"], stderr=subprocess.STDOUT, cwd=destination)
-      subprocess.check_call(["git", "reset", "--hard", "origin/master"], stderr=subprocess.STDOUT, cwd=destinationReal)
+      subprocess.check_call(["git", "reset", "--hard", refFilesGitTag], stderr=subprocess.STDOUT, cwd=destinationReal)
       subprocess.check_call(["git", "clean", "-fdx", "--exclude=*.hash"], stderr=subprocess.STDOUT, cwd=destinationReal)
       subprocess.check_call(["find", ".", "-name", "*.mat.xz", "-exec", "xz", "--decompress", "--keep", "{}", ";"], stderr=subprocess.STDOUT, cwd=destinationReal)
       githash = subprocess.check_output(["git", "rev-parse", "--verify", "HEAD"], stderr=subprocess.STDOUT, cwd=destinationReal)


### PR DESCRIPTION
## Related Issues

Fixes #54.

## Changes

Added git reference (branch, tag, hash) and sub-directory inside the git repository to set reference files.

```
  {
    "library": "PNlib",
    "libraryVersion": "2.2.0",
    "referenceFileExtension":"mat",
    "referenceFileNameDelimiter":".",
    "referenceFiles":{
      "giturl":"https://github.com/AMIT-HSBI/PNlib",
      "destination":"ReferenceFiles/PNlib",
      "git-ref": "v2.2",                                             <- new
      "git-directory": "ReferenceFiles"                              <- new
    }
  }
```