### PR TITLE
Windows support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,10 @@ jobs:
     name: GitHub Actions Test
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         omc-version: [stable, nightly]
         python-version: ['3.10']
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
 
     steps:
@@ -68,7 +69,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: ${{ matrix.omc-version }}-sqlite3.db
+          name: ${{ matrix.os }}-${{ matrix.omc-version }}-sqlite3.db
           path: |
             sqlite3.db
 
@@ -76,5 +77,5 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: ${{ matrix.omc-version }}-PNlib.html
+          name: ${{ matrix.os }}-${{ matrix.omc-version }}-PNlib.html
           path: html/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,8 +61,8 @@ jobs:
       - name: Verify that overview.html contains simulation and verification
         shell: bash
         run: |
-          if ! grep -q "<tr><td><a href=\"${{ matrix.omc-version }}/PNlib_2.2.0/PNlib_2.2.0.html\">${{ matrix.omc-version }}</a></td><td><a>93</a></td><td><a>93</a></td><td><a>92</a></td><td><a>92</a></td><td><a>92</a></td><td><a>92</a></td><td><a>92</a></td><td><a>91</a></td><td><a>90</a></td></tr></table>" overview.html; then
-            echo "Failed to find 93 simulating and 90 verifying models in overwiew.html:"
+          if ! grep -q "<tr><td><a href=\"${{ matrix.omc-version }}/PNlib_2.2.0/PNlib_2.2.0.html\">${{ matrix.omc-version }}</a></td><td><a>92</a></td><td><a>92</a></td><td><a>92</a></td><td><a>92</a></td><td><a>92</a></td><td><a>92</a></td><td><a>92</a></td><td><a>92</a></td><td><a>92</a></td></tr></table>" overview.html; then
+            echo "Failed to find 92 simulating and 92 verifying models in overwiew.html:"
             cat overview.html
             exit 1
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,11 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         omc-version: [stable, nightly]
         python-version: ['3.10']
+        include:
+          - os: windows-latest
+            librariesPath: ${{ env.APPDATA }}\.openmodelica\libraries
+          - os: ubuntu-latest
+            librariesPath: ${{ env.HOME }}/.openmodelica/libraries
       fail-fast: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -46,7 +51,8 @@ jobs:
 
       - name: Run library test
         shell: bash
-        run: python test.py --branch="${{ matrix.omc-version }}" --noclean --verbose configs/sanityCheck.json
+        run: |
+          python test.py --branch="${{ matrix.omc-version }}" --noclean --verbose --libraries ${{ matrix.librariesPath }} configs/sanityCheck.json
 
       - name: Generate HTML results
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         omc-version: [stable, nightly]
         python-version: ['3.10']
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         omc-version: [stable, nightly]
         python-version: ['3.10']
-      include:
-        - os: windows-latest
-          omc-version: stable
-          msysEnvironment: --msysEnvironment=mingw64
+        include:
+          - os: windows-latest
+            omc-version: stable
+            msysEnvironment: --msysEnvironment=mingw64
       fail-fast: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,6 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         omc-version: [stable, nightly]
         python-version: ['3.10']
-        include:
-          - os: windows-latest
-            librariesPath: ${{ env.APPDATA }}\.openmodelica\libraries
-          - os: ubuntu-latest
-            librariesPath: ${{ env.HOME }}/.openmodelica/libraries
       fail-fast: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -52,7 +47,7 @@ jobs:
       - name: Run library test
         shell: bash
         run: |
-          python test.py --branch="${{ matrix.omc-version }}" --noclean --verbose --libraries ${{ matrix.librariesPath }} configs/sanityCheck.json
+          python test.py --branch="${{ matrix.omc-version }}" --noclean --verbose configs/sanityCheck.json
 
       - name: Generate HTML results
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,10 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         omc-version: [stable, nightly]
         python-version: ['3.10']
+      include:
+        - os: windows-latest
+          omc-version: stable
+          msysEnvironment: --msysEnvironment=mingw64
       fail-fast: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -47,7 +51,7 @@ jobs:
       - name: Run library test
         shell: bash
         run: |
-          python test.py --branch="${{ matrix.omc-version }}" --noclean --verbose configs/sanityCheck.json
+          python test.py --branch="${{ matrix.omc-version }}" --noclean --verbose ${{ matrix.msysEnvironment }} configs/sanityCheck.json
 
       - name: Generate HTML results
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
             'omc'
           libraries: |
             'Modelica 4.0.0'
-            'PNlib 2.2.0'
+            'PNlib 3.0.0'
           omc-diff: true
 
       - name: Setup Python3
@@ -56,12 +56,12 @@ jobs:
       - name: Zip HTML results
         shell: bash
         run: |
-          python .github/scripts/archiveResults.py "PNlib" "2.2.0" "${{ matrix.omc-version }}" "html/"
+          python .github/scripts/archiveResults.py "PNlib" "3.0.0" "${{ matrix.omc-version }}" "html/"
 
       - name: Verify that overview.html contains simulation and verification
         shell: bash
         run: |
-          if ! grep -q "<tr><td><a href=\"${{ matrix.omc-version }}/PNlib_2.2.0/PNlib_2.2.0.html\">${{ matrix.omc-version }}</a></td><td><a>92</a></td><td><a>92</a></td><td><a>92</a></td><td><a>92</a></td><td><a>92</a></td><td><a>92</a></td><td><a>92</a></td><td><a>92</a></td><td><a>92</a></td></tr></table>" overview.html; then
+          if ! grep -q "<tr><td><a href=\"${{ matrix.omc-version }}/PNlib_3.0.0/PNlib_3.0.0.html\">${{ matrix.omc-version }}</a></td><td><a>92</a></td><td><a>92</a></td><td><a>92</a></td><td><a>92</a></td><td><a>92</a></td><td><a>92</a></td><td><a>92</a></td><td><a>92</a></td><td><a>92</a></td></tr></table>" overview.html; then
             echo "Failed to find 92 simulating and 92 verifying models in overwiew.html:"
             cat overview.html
             exit 1

--- a/configs/sanityCheck.json
+++ b/configs/sanityCheck.json
@@ -1,13 +1,13 @@
 [
   {
     "library": "PNlib",
-    "libraryVersion": "2.2.0",
+    "libraryVersion": "3.0.0",
     "referenceFileExtension":"mat",
     "referenceFileNameDelimiter":".",
     "referenceFiles":{
       "giturl":"https://github.com/AMIT-HSBI/PNlib",
       "destination":"ReferenceFiles/PNlib",
-      "git-ref": "v2.2",
+      "git-ref": "v3.0.0",
       "git-directory": "ReferenceFiles"
     }
   }

--- a/shared.py
+++ b/shared.py
@@ -11,7 +11,6 @@ def fixData(data,abortSimulationFlag,alarmFlag,overrideDefaults,defaultCustomCom
   try:
     data["runOnceBeforeTesting"] = (data.get("runOnceBeforeTesting") or [])
     data["simCodeTarget"] = data.get("simCodeTarget") or "C"
-    data["referenceFiles"] = os.path.abspath(data.get("referenceFiles")) if data.get("referenceFiles") else ""
     data["referenceFileExtension"] = data.get("referenceFileExtension") or "mat"
     data["referenceFileNameDelimiter"] = data.get("referenceFileNameDelimiter") or "."
     data["default_tolerance"] = float(data.get("default_tolerance") or 1e-6)
@@ -72,7 +71,7 @@ def getReferenceFileName(conf):
         modelName += "."+(modelName.split(".")[-1])
       else:
         modelName += "."+conf["referenceFileNameExtraName"]
-    referenceFile = os.path.normpath(conf["referenceFiles"]+"/"+modelName.replace(".",conf["referenceFileNameDelimiter"])+(conf.get("referenceFinalDot") or ".")+conf["referenceFileExtension"])
+    referenceFile = conf["referenceFiles"]+"/"+modelName.replace(".",conf["referenceFileNameDelimiter"])+(conf.get("referenceFinalDot") or ".")+conf["referenceFileExtension"]
     if not os.path.exists(referenceFile) and not os.path.isdir(referenceFile):
       if conf.get("allReferenceFilesExist"):
         raise Exception("Missing reference file %s for config %s" % (referenceFile,conf))

--- a/test.py
+++ b/test.py
@@ -39,8 +39,8 @@ parser.add_argument('--default', action='append', help="Add a default value for 
 parser.add_argument('-j', '--jobs', default=0)
 parser.add_argument('-v', '--verbose', action="store_true", help="Verbose mode.", default=False)
 parser.add_argument('--execAllTests', action="store_true", help="Force all tests to be executed", default=False)
-parser.add_argument('--win', action="store_true", default=False)
-parser.add_argument('--noSync', action="store_true", default=False)
+parser.add_argument('--win', action="store_true", help="Windows mode", default=False)
+parser.add_argument('--noSync', action="store_true", help="Move files using python instead of rsync", default=False)
 parser.add_argument('--timeout', default=0, help="=[value] timeout in seconds for each test, it overrides the timeout calculated by the script")
 
 args = parser.parse_args()

--- a/test.py
+++ b/test.py
@@ -28,7 +28,7 @@ parser.add_argument('--branch', default='master')
 parser.add_argument('--fmi', default=False)
 parser.add_argument('--output', default='')
 parser.add_argument('--docker', default='')
-parser.add_argument('--libraries', help="Directory omc will search in to load system libraries/libraries to test.", default=os.path.normpath(os.path.expanduser('~/.openmodelica/libraries/')))
+parser.add_argument('--libraries', help="Directory omc will search in to load system libraries/libraries to test.", default='')
 parser.add_argument('--extraflags', default='')
 parser.add_argument('--extrasimflags', default='')
 parser.add_argument('--ompython_omhome', default='')
@@ -56,11 +56,19 @@ fmisimulator = args.fmisimulator or None
 allTestsFmi = args.fmi
 ulimitMemory = args.ulimitvmem
 docker = args.docker
-librariespath = os.path.abspath(os.path.normpath(args.libraries))
+isWin = os.name == 'nt'
+librariespath = ''
+if args.libraries:
+  librariespath = os.path.abspath(os.path.normpath(args.libraries))
+else:
+  if isWin:
+    librariespath = os.path.normpath(os.path.join(os.environ.get('APPDATA'), '.openmodelica', 'libraries'))
+  else:
+    librariespath = os.path.normpath(os.path.join(os.environ.get('HOME'), '.openmodelica', 'libraries'))
 overrideDefaults = [arg.split("=", 1) for arg in args.default]
 execAllTests = args.execAllTests
 noSync = args.noSync
-isWin = os.name == 'nt'
+
 exeExt = ".exe" if isWin else ""
 customTimeout = int(args.timeout)
 

--- a/test.py
+++ b/test.py
@@ -139,10 +139,7 @@ def runCommand(cmd, prefix, timeout):
   return 1 if gotTimeout else process[0].returncode
 
 try:
-  if isWin:
-    subprocess.check_output(["python", "testmodel.py", "--help"], stderr=subprocess.STDOUT)
-  else:
-    subprocess.check_output(["./testmodel.py", "--help"], stderr=subprocess.STDOUT)
+  subprocess.check_output(["python", "testmodel.py", "--help"], stderr=subprocess.STDOUT)
 
 except subprocess.CalledProcessError as e:
   print("Sanity check failed (./testmodel.py --help):\n" + e.output.decode())
@@ -184,11 +181,7 @@ else:
   commands = []
   dockerExtraArgs = []
   if os.environ.get("OPENMODELICAHOME"):
-    if isWin:
-      omc_cmd = ["%sbin\\omc" % os.environ.get("OPENMODELICAHOME")]
-    else:
-      omc_cmd = ["%s/bin/omc" % os.environ.get("OPENMODELICAHOME")]
-
+    omc_cmd = [os.path.normpath(os.path.join(os.environ.get("OPENMODELICAHOME"), 'bin', 'omc'))]
   else:
     omc_cmd = ["omc"]
 if result_location != "" and not os.path.exists(result_location):
@@ -199,8 +192,6 @@ if configs == []:
   sys.exit(1)
 
 from OMPython import OMCSession, OMCSessionZMQ
-
-version_cmd = "--version"
 
 # Try to make the processes a bit nicer...
 os.environ["GC_MARKERS"]="1"
@@ -235,7 +226,7 @@ sys.stdout.flush()
 
 # Do feature checks. Handle things like old RML-style arguments...
 
-subprocess.check_output(omc_cmd + ["-n=1", version_cmd], stderr=subprocess.STDOUT).strip()
+subprocess.check_output(omc_cmd + ["-n=1", "--version"], stderr=subprocess.STDOUT).strip()
 
 sys.stdout.flush()
 

--- a/test.py
+++ b/test.py
@@ -687,7 +687,7 @@ def runScript(c, timeout, memoryLimit, verbose):
     sys.stdout.flush()
 
   if isWin:
-    res_cmd = runCommand("python testmodel.py --win --msysEnvironment=%s --libraries=%s %s --ompython_omhome=%s %s.conf.json > files/%s.cmdout 2>&1" % (librariespath, ("--docker %s --dockerExtraArgs '%s'" % (msysEnvironment, docker, " ".join(dockerExtraArgs))) if docker else "", ompython_omhome, c, c), prefix=c, timeout=timeout)
+    res_cmd = runCommand("python testmodel.py --win --msysEnvironment=%s --libraries=%s %s --ompython_omhome=%s %s.conf.json > files/%s.cmdout 2>&1" % (msysEnvironment, librariespath, ("--docker %s --dockerExtraArgs '%s'" % (docker, " ".join(dockerExtraArgs))) if docker else "", ompython_omhome, c, c), prefix=c, timeout=timeout)
   else:
     res_cmd = runCommand("ulimit -v %d; ./testmodel.py --libraries=%s %s --ompython_omhome=%s %s.conf.json > files/%s.cmdout 2>&1" % (memoryLimit, librariespath, ("--docker %s --dockerExtraArgs '%s'" % (docker, " ".join(dockerExtraArgs))) if docker else "", ompython_omhome, c, c), prefix=c, timeout=timeout)
 

--- a/testmodel.py
+++ b/testmodel.py
@@ -15,7 +15,7 @@ parser.add_argument('--libraries')
 parser.add_argument('--docker')
 parser.add_argument('--dockerExtraArgs')
 parser.add_argument('--corba', action="store_true", default=False)
-parser.add_argument('--win', action="store_true", default=False)
+parser.add_argument('--win', action="store_true", help="Windows mode", default=False)
 
 args = parser.parse_args()
 config = args.config

--- a/testmodel.py
+++ b/testmodel.py
@@ -428,7 +428,7 @@ try:
       execstat["phase"] = 5
   else:
     if isWin:
-      res = checkOutputTimeout("\"%s\\share\\omc\\scripts\\Compile.bat\" %s gcc %s parallel dynamic 24 0" % (conf["omhome"], conf["fileName"]), msysEnvironment, conf["ulimitOmc"], conf)
+      res = checkOutputTimeout("\"%s\\share\\omc\\scripts\\Compile.bat\" %s gcc %s parallel dynamic 24 0" % (conf["omhome"], conf["fileName"], msysEnvironment), conf["ulimitOmc"], conf)
     else:
       res = checkOutputTimeout("make -j1 -f %s.makefile" % conf["fileName"], conf["ulimitOmc"], conf)
 


### PR DESCRIPTION
This PR partially solves the issue #57, by implement a  partial windows integration. This integration has been tested on Win11 pro and it is intended to be used to test modelica libraries locally, on demand or by using a local scheduler.

**Not implemented:**
- FMI integration
- Docker integration

**Not Tested:**
- connection to a remote repository
- remote URL for reference files

**Implementation notes:**
1. the following arguments have been added:
- `--win (default = False)`, to activate the windows integration. If --win = False the script runs on linux and all the original features are avalable
- `--execAllTests (default = False)`, to force the execution of all tests independently from the last execution date and time
- `--noSync (default = False)`, to move files by using python commands instead of rsync, that is not available on windows
- `--timeout [value] (default = 0)`, to override the timeout calculated by the script. Override is done if value > 0

2. arguments parsing has been moved to the beginning of the `test.py` script because the value of the argument `--win` shall be available in the entire script

**Known issues:**
- the `dygraphs` cannot access the `.csv` files if they are stored in local, this because it performs an XMLHttpRequest to retrieve said files (XMLHttpRequest does not allow the access to local files).
- under windows the long paths in the name models are not properly managed, models with long path fail the test 
