### PR TITLE
Use sys.executable instead of "python"

### DIFF
--- a/test.py
+++ b/test.py
@@ -73,6 +73,10 @@ msysEnvironment = args.msysEnvironment
 exeExt = ".exe" if isWin else ""
 customTimeout = int(args.timeout)
 
+pythonExecutable = sys.executable
+if not pythonExecutable:
+  pythonExecutable = "python"
+
 def rmtree(f):
   try:
     shutil.rmtree(f)
@@ -145,7 +149,7 @@ def runCommand(cmd, prefix, timeout):
   return 1 if gotTimeout else process[0].returncode
 
 try:
-  subprocess.check_output(["python", "testmodel.py", "--help"], stderr=subprocess.STDOUT)
+  subprocess.check_output([pythonExecutable, "testmodel.py", "--help"], stderr=subprocess.STDOUT)
 
 except subprocess.CalledProcessError as e:
   print("Sanity check failed (./testmodel.py --help):\n" + e.output.decode())
@@ -684,7 +688,7 @@ def runScript(c, timeout, memoryLimit, verbose):
     sys.stdout.flush()
 
   if isWin:
-    res_cmd = runCommand("python testmodel.py --win --msysEnvironment=%s --libraries=%s %s --ompython_omhome=%s %s.conf.json > files/%s.cmdout 2>&1" % (msysEnvironment, librariespath, ("--docker %s --dockerExtraArgs '%s'" % (docker, " ".join(dockerExtraArgs))) if docker else "", ompython_omhome, c, c), prefix=c, timeout=timeout)
+    res_cmd = runCommand("%s testmodel.py --win --msysEnvironment=%s --libraries=%s %s --ompython_omhome=%s %s.conf.json > files/%s.cmdout 2>&1" % (pythonExecutable, msysEnvironment, librariespath, ("--docker %s --dockerExtraArgs '%s'" % (docker, " ".join(dockerExtraArgs))) if docker else "", ompython_omhome, c, c), prefix=c, timeout=timeout)
   else:
     res_cmd = runCommand("ulimit -v %d; ./testmodel.py --libraries=%s %s --ompython_omhome=%s %s.conf.json > files/%s.cmdout 2>&1" % (memoryLimit, librariespath, ("--docker %s --dockerExtraArgs '%s'" % (docker, " ".join(dockerExtraArgs))) if docker else "", ompython_omhome, c, c), prefix=c, timeout=timeout)
 


### PR DESCRIPTION
Fixes #67.

> A string giving the absolute path of the executable binary for the Python interpreter, on systems where this makes sense. If Python is unable to retrieve the real path to its executable, [sys.executable](https://docs.python.org/3/library/sys.html#sys.executable) will be an empty string or None.

I hope there aren't many systems where [sys.executable](https://docs.python.org/3/library/sys.html#sys.executable) isn't set. But if so try `"python"`.