### PR TITLE
Update installLibraries.mos for Buildings

### DIFF
--- a/.CI/installLibraries.mos
+++ b/.CI/installLibraries.mos
@@ -9,7 +9,7 @@ for v in {"3.2.1","3.2.2","3.2.3","4.0.0","trunk"} loop
     exit(1);
   end if;
 end for;
-for v in {"1.6", "3.0.0", "maint.7.0.x", "maint.8.1.x", "maint.9.1.x", "maint.10.0.x", "master"} loop
+for v in {"maint.10.0.x", "maint.11.x", "master"} loop
   if not installPackage(Buildings, v) then
     print("Buildings " + v + " " + getErrorString() + "\n");
     exit(1);


### PR DESCRIPTION
Added branch 11.x (not 11.0.x as required by @mwetter) and removed old branches which are no longer tested.