### PR TITLE
Preliminary cleaning of the ./file dir under Win or if the flag noSync is set

### DIFF
--- a/test.py
+++ b/test.py
@@ -117,6 +117,20 @@ def print_linenum(signum, frame):
 if not isWin:
   signal.signal(signal.SIGUSR1, print_linenum)
 
+if isWin:
+  # delete temporary ./files to avoid moving of old results (win does not use rsync)
+  try:
+    rmtree("./files")
+    print("Cleaned files directory")
+  except OSError:
+    pass
+  try:
+    os.mkdir("files")
+  except OSError:
+    pass
+  print("Created files directory")
+  sys.stdout.flush()
+
 def runCommand(cmd, prefix, timeout):
   process = [None]
   def target():

--- a/test.py
+++ b/test.py
@@ -117,7 +117,7 @@ def print_linenum(signum, frame):
 if not isWin:
   signal.signal(signal.SIGUSR1, print_linenum)
 
-if isWin:
+if isWin or noSync:
   # delete temporary ./files to avoid moving of old results (win does not use rsync)
   try:
     rmtree("./files")


### PR DESCRIPTION
Under Windows or if the --noSync flag is set the results files are moved/copied depending on the current value of the --clean flag. This means that if the --clean flag is = False the new test will find and copy to the result dir all the old files that are not overwritten by the new test itself.

To avoid this issue the best way is to clean the ./files directory when a new library test is started, independently from the value of the --clean flag.

This PR adds a preliminary clean of the ./files dir if the detected os is Windows or the flag noSync is set. Probably this is not necessary under linux if rsync is used to move the results files.