### PR TITLE
Removed old Buildings libraries from installation script

### DIFF
--- a/.CI/installLibraries.mos
+++ b/.CI/installLibraries.mos
@@ -20,7 +20,7 @@ for v in {"3.2.1","3.2.2","3.2.3","4.0.0","4.1.0-beta.om","trunk"} loop
     exit(1);
   end if;
 end for;
-for v in {"1.6", "3.0.0", "maint.7.0.x", "maint.8.1.x", "maint.9.1.x", "maint.10.0.x", "maint.11.x", "maint.12.x", "master"} loop
+for v in {"maint.11.x", "maint.12.x", "master"} loop
   if not installPackage(Buildings, v) then
     print("Buildings " + v + " " + getErrorString() + "\n");
     exit(1);


### PR DESCRIPTION
We dropped testing Buildings up to and including version 10.x, no need to install them (they are huge!)