### PR TITLE
Fixing typo in Jenkinsfile

### DIFF
--- a/.CI/Jenkinsfile
+++ b/.CI/Jenkinsfile
@@ -700,7 +700,7 @@ def runRegressiontest(branch, name, extraFlags, omsHash, dbPrefix, sshConfig, om
     ${env.HOME}/saved_omc/OMSimulator/install/bin/OMSimulator --version
     """
     FMI_TESTING_FLAG="--fmi=true --fmisimulator=${env.HOME}/saved_omc/OMSimulator/install/bin/OMSimulator --default=ulimitExe=50"
-    if (name.containts('cvode')) {
+    if (name.contains('cvode')) {
       FMI_TESTING_FLAG += "--fmuType='cs'"
     }
   }

--- a/.github/workflows/test_julia.yml
+++ b/.github/workflows/test_julia.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - master
-    tags: '*'
+    tags: ['*']
 
 jobs:
   unittest-testbasemodelica:


### PR DESCRIPTION
## Issue

Typo in Jenkinsfile breaks FMI tests.

```
groovy.lang.MissingMethodException: No signature of method: java.lang.String.containts() is applicable for argument types: (java.lang.String) values: [cvode]

Possible solutions: contains(java.lang.CharSequence), contains(java.lang.CharSequence), concat(java.lang.String), codePoints()
```