### PR TITLE
Catch loadModel errors

### DIFF
--- a/test.py
+++ b/test.py
@@ -259,7 +259,7 @@ if configs == []:
   print("Error: Expected at least one configuration file to start the library test")
   sys.exit(1)
 
-from OMPython import OMCSessionZMQ, OMCProcessDocker
+from OMPython import OMCSessionZMQ, OMCProcessDocker, OMCSessionException
 
 # Try to make the processes a bit nicer...
 os.environ["GC_MARKERS"]="1"
@@ -663,7 +663,9 @@ for (library,conf) in configs:
         raise Exception("Library %s has both libraryVersionLatestInPackageManager:true and libraryVersionExactMatch:true! Make up your mind." % libName)
       exactMatch=', requireExactVersion=true'
 
-    if not omc.sendExpression('loadModel(%s,%s%s)' % (lib,versions,exactMatch)):
+    try:
+      omc.sendExpression('loadModel(%s,%s%s)' % (lib,versions,exactMatch))
+    except OMCSessionException:
       try:
         print("Failed to load library %s %s: %s" % (library,versions,omc.sendExpression('OpenModelica.Scripting.getErrorString()')))
       except:
@@ -726,7 +728,7 @@ for (library,conf) in configs:
   if conf.get("fmi") and fmisimulatorversion:
     conf["libraryVersionRevision"] = conf["libraryVersionRevision"] + " " + fmisimulatorversion.decode("ascii")
     conf["libraryLastChange"] = conf["libraryLastChange"] + " " + fmisimulatorversion.decode("ascii")
-  res=omc.sendExpression('{c for c guard isExperiment(c) and not regexBool(typeNameString(x), "^Modelica_Synchronous\\.WorkInProgress") in getClassNames(%s, recursive=true)}' % library)
+  res=omc.sendExpression('{c for c guard isExperiment(c) and not regexBool(typeNameString(x), "^Modelica_Synchronous\\\\.WorkInProgress") in getClassNames(%s, recursive=true)}' % library)
   if conf.get("ignoreModelPrefix"):
     if isinstance(conf["ignoreModelPrefix"], list):
       prefixes = conf["ignoreModelPrefix"]


### PR DESCRIPTION
## Issue 

Loading a broken library crashes the script:

```
Skipping IDEAS as we already have results for it: (1762983975, '3.0.0 (https://github.com/open-ideas/IDEAS/archive/a7be00b7e07943c0acda1b5799a8d32bea896d7b.zip)', 'IDEAS', 'master', 'OMCompiler v1.26.0-dev.473+g1d95b24818')
Traceback (most recent call last):
  File "/var/lib/jenkins/ws/OpenModelicaLibraryTestingWork/OpenModelicaLibraryTesting/./test.py", line 666, in <module>
    if not omc.sendExpression('loadModel(%s,%s%s)' % (lib,versions,exactMatch)):
  File "/usr/local/lib/python3.10/dist-packages/OMPython/OMCSession.py", line 410, in sendExpression
    raise OMCSessionException(msg)
OMPython.OMCSession.OMCSessionException: [OMC log for 'sendExpression(loadModel(IDEAS,{"master"}), True)']: [syntax:error:2] No viable alternative near token: break
Command exited with non-zero status 1
117.91user 33.54system 1:12.69elapsed 208%CPU (0avgtext+0avgdata 1608836maxresident)k
401840inputs+1794112outputs (79649major+6121527minor)pagefaults 0swaps
+ killall omc
omc: no process found
```

## Changes

  - `omc.sendExpression` now throws `OMCSessionException` when failing to load.
  - Handle it with a try block.