### PR TITLE
Revert unrealed change to regex

### DIFF
--- a/test.py
+++ b/test.py
@@ -728,7 +728,7 @@ for (library,conf) in configs:
   if conf.get("fmi") and fmisimulatorversion:
     conf["libraryVersionRevision"] = conf["libraryVersionRevision"] + " " + fmisimulatorversion.decode("ascii")
     conf["libraryLastChange"] = conf["libraryLastChange"] + " " + fmisimulatorversion.decode("ascii")
-  res=omc.sendExpression('{c for c guard isExperiment(c) and not regexBool(typeNameString(x), "^Modelica_Synchronous\\\\.WorkInProgress") in getClassNames(%s, recursive=true)}' % library)
+  res=omc.sendExpression('{c for c guard isExperiment(c) and not regexBool(typeNameString(x), "^Modelica_Synchronous\\.WorkInProgress") in getClassNames(%s, recursive=true)}' % library)
   if conf.get("ignoreModelPrefix"):
     if isinstance(conf["ignoreModelPrefix"], list):
       prefixes = conf["ignoreModelPrefix"]


### PR DESCRIPTION
## Issue

Fixing one and breaking the other. I need to improve the CI!

```
Skipping IDEAS as we already have results for it: (1762983975, '3.0.0 (https://github.com/open-ideas/IDEAS/archive/a7be00b7e07943c0acda1b5799a8d32bea896d7b.zip)', 'IDEAS', 'master', 'OMCompiler v1.26.0-dev.473+g1d95b24818')
Failed to load library IDEAS {"master"}: 
Traceback (most recent call last):
  File "/var/lib/jenkins/ws/OpenModelicaLibraryTestingWork/OpenModelicaLibraryTesting/./test.py", line 731, in <module>
    res=omc.sendExpression('{c for c guard isExperiment(c) and not regexBool(typeNameString(x), "^Modelica_Synchronous\\\\.WorkInProgress") in getClassNames(%s, recursive=true)}' % library)
  File "/usr/local/lib/python3.10/dist-packages/OMPython/OMCSession.py", line 410, in sendExpression
    raise OMCSessionException(msg)
OMPython.OMCSession.OMCSessionException: [OMC log for 'sendExpression({c for c guard isExperiment(c) and not regexBool(typeNameString(x), "^Modelica_Synchronous\\.WorkInProgress") in getClassNames(IDEAS, recursive=true)}, True)']: [translation:error:3] Class IDEAS not found in scope <TOP>.
Command exited with non-zero status 1
119.30user 33.04system 1:06.24elapsed 229%CPU (0avgtext+0avgdata 1558004maxresident)k
0inputs+1785976outputs (79393major+6075255minor)pagefaults 0swaps
```