### PR TITLE
Only import basemodelica if needed

### DIFF
--- a/test.py
+++ b/test.py
@@ -19,7 +19,6 @@ from natsort import natsorted
 from shared import readConfig, getReferenceFileName, simulationAcceptsFlag, isFMPy
 from platform import processor
 import shared
-import basemodelica
 
 import signal
 
@@ -320,6 +319,9 @@ sys.stdout.flush()
 # Print Julia versions for BaseModelica.jl import
 julia_sysimage = os.path.abspath("TestBaseModelica.so") if julia_sys_image else None
 if basemodelica_mtk_import:
+  # Only import basemodelica if needed.
+  # Python package juliacall will install Julia and can fail with unsatisfiable requirments.
+  import basemodelica
   basemodelica.print_julia_version()
   basemodelica.precompile_testbaesmodelica(julia_sysimage)
 


### PR DESCRIPTION
## Issue

The Jenkins default jobs (without Julia) are failing because of

```bash
$ stdbuf -oL -eL time ./test.py --ompython_omhome=/usr --extraflags= --extrasimflags= --branch=master --output=libraries.openmodelica.org:/var/www/libraries.openmodelica.org/branches/master/ --libraries=/home/hudson/saved_omc/libraries/.openmodelica/libraries/ --jobs=0 configs/conf.json
    Updating registry at `~/.julia/registries/General.toml`
   Resolving package versions...
ERROR: Unsatisfiable requirements detected for package OpenSSL_jll [458c3c95]:
 OpenSSL_jll [458c3c95] log:
 ├─possible versions are: 3.5.4 or uninstalled
 └─restricted to versions 3.0 by project [4facbee2] — no versions left
   └─project [4facbee2] log:
     ├─possible versions are: 0.0.0 or uninstalled
     └─project [4facbee2] is fixed to version 0.0.0
```

https://test.openmodelica.org/jenkins/blue/organizations/jenkins/LibraryTesting%2FLibraryTest/detail/LibraryTest/10566/pipeline

## Changes

* Only import Python package `juliacall` if really needed.