### PR TITLE
Fix OMSimulator submodule update when directory layout changes

### DIFF
--- a/.CI/Jenkinsfile
+++ b/.CI/Jenkinsfile
@@ -715,8 +715,9 @@ def runRegressiontest(branch, name, extraFlags, omsHash, dbPrefix, sshConfig, om
 
     if ! (cmp ~/saved_omc/OMSimulator/.githash .newhash); then
 
-      git submodule update || exit 1
-      git clean -fdx || exit 1
+      git submodule sync --recursive || exit 1
+      git clean -ffdx || exit 1
+      git submodule update --init --recursive --force || exit 1
       git submodule foreach --recursive  "git fetch --tags --force && git reset --hard && git clean -fdxq -e /git -e /svn" || exit 1
       cmake -S . -B build/ -DCMAKE_INSTALL_PREFIX=install/
       cmake --build build/ --target install || exit 1


### PR DESCRIPTION
## Issue

I changed the layout of OMSimulator submodules in https://github.com/OpenModelica/OMSimulator-3rdParty/pull/98. This broke the library testing CI:

https://test.openmodelica.org/jenkins/blue/organizations/jenkins/LibraryTesting%2FLibraryTest/detail/LibraryTest/11099/pipeline/39/

```
CMake Error at 3rdParty/CMakeLists.txt:146 (add_subdirectory):
  The source directory

    /var/lib/jenkins/ws/OpenModelicaLibraryTestingWork/OMSimulator/3rdParty/libzip

  does not contain a CMakeLists.txt file.


CMake Error at 3rdParty/CMakeLists.txt:147 (add_library):
  add_library cannot create ALIAS target "oms::3rd::libzip" because target
  "zip" does not already exist.
```

## Changes

Clean the working tree (including nested git repos) before running submodule update, so that directories that were replaced by submodules (or vice versa) don't block initialization.