### PR TITLE
Pass the count of re.sub by keyword

### DIFF
--- a/test.py
+++ b/test.py
@@ -1043,7 +1043,7 @@ def cpu_name():
   else:
     for line in open("/proc/cpuinfo").readlines():
       if "model name" in line.strip():
-        return (re.sub( ".*model name.*:", "", line,1)).strip()
+        return (re.sub( ".*model name.*:", "", line, count=1)).strip()
 
 if isWin:
   lsb_release = ""


### PR DESCRIPTION
Python 3.13 deprecates giving re.sub its count positionally, so every library test run printed

  test.py:1046: DeprecationWarning: 'count' is passed as positional argument
    return (re.sub( ".*model name.*:", "", line,1)).strip()

once per job while reading the processor name out of /proc/cpuinfo. The substitution is unchanged; only how the argument is spelled.

A run of configs/sanityCheck.json now goes through without a single DeprecationWarning.

---
Generated by Claude Code.