### PR TITLE
Survive losing the connection to the results database

### DIFF
--- a/resultsdb.py
+++ b/resultsdb.py
@@ -122,6 +122,16 @@ class _Db:
   def close(self):
     self.conn.close()
 
+  # The errors that mean the connection is gone rather than the statement bad.
+  lostConnection = ()
+
+  def record(self, statement, params):
+    """Remember a statement in case the transaction has to be replayed."""
+
+  def recover(self):
+    """Reconnect after the connection was lost and replay the transaction."""
+    raise NotImplementedError
+
   def insertIgnore(self):
     """The clause that makes an INSERT skip a row that is already there."""
     return ""
@@ -159,7 +169,19 @@ class _Cursor:
     # psycopg2 only looks for placeholders when parameters are passed, so a
     # statement without any must not be handed an empty tuple.
     params = tuple(params)
-    self.cursor.execute(self.db.sql(sql, bool(params)), self.db.params(params))
+    statement = self.db.sql(sql, bool(params))
+    try:
+      self.cursor.execute(statement, self.db.params(params))
+    except self.db.lostConnection as e:
+      # The results of a run are written in one transaction at the end of it,
+      # after the connection has been idle for hours, which is exactly when a
+      # firewall or a restarted server has dropped it. Reconnecting and
+      # replaying what the transaction had so far costs nothing and saves the
+      # whole run; the keys make replaying it harmless.
+      print("Lost the connection to the database (%s); reconnecting" % str(e).strip())
+      self.cursor = self.db.recover()
+      self.cursor.execute(statement, self.db.params(params))
+    self.db.record(statement, self.db.params(params))
     return self
 
   def fetchone(self):
@@ -254,13 +276,64 @@ class _Postgres(_Db):
     # The password belongs in PGPASSWORD or ~/.pgpass, not in the URL.
     _fixPgpassPermissions()
     self.url = url
-    self.conn = psycopg2.connect(url)
-    self.conn.autocommit = False
+    self.lostConnection = (psycopg2.OperationalError, psycopg2.InterfaceError)
+    self.pending = []
+    self.conn = self._connect()
     self.host = socket.gethostname()
     self.claims = []
     self.heartbeatThread = None
     self.execute(JOB_CLAIM)
     self.commit()
+
+  def _connect(self):
+    """Open the connection, asking the kernel to keep it alive.
+
+    A run holds this connection open while it tests, which is hours during
+    which nothing is sent on it, and an idle connection is what a firewall or
+    a NAT quietly drops. The keepalives make that visible rather than fatal.
+    """
+    import psycopg2
+    conn = psycopg2.connect(self.url, keepalives=1, keepalives_idle=60,
+                            keepalives_interval=10, keepalives_count=5)
+    conn.autocommit = False
+    return conn
+
+  # Only what changes the database has to be replayed; a run also makes tens of
+  # thousands of queries, which would fill the buffer for nothing.
+  WRITES = ("insert", "update", "delete", "create", "drop", "alter")
+
+  def record(self, statement, params):
+    first = statement.lstrip().split(None, 1)
+    if first and first[0].lower() in self.WRITES:
+      self.pending.append((statement, params))
+
+  def recover(self):
+    """Reconnect and replay the transaction that the lost connection took.
+
+    Everything a run writes is an insert guarded by a key, so replaying it can
+    only produce the rows that were lost, never a duplicate.
+    """
+    try:
+      self.conn.close()
+    except Exception:
+      pass
+    self.conn = self._connect()
+    cursor = self.conn.cursor()
+    for (statement, params) in self.pending:
+      cursor.execute(statement, params)
+    if self.pending:
+      print("Replayed %d statements of the interrupted transaction" % len(self.pending))
+    return cursor
+
+  def commit(self):
+    try:
+      self.conn.commit()
+    except self.lostConnection as e:
+      print("Lost the connection to the database while committing (%s); reconnecting"
+            % str(e).strip())
+      self.recover()
+      self.conn.commit()
+    self.pending = []
 
   def sql(self, sql, hasParams=False):
     """sqlite spells the placeholder "?" and psycopg2 spells it "%s".


### PR DESCRIPTION
A run opens its connection to the results database, claims its libraries, and then tests for hours before writing anything: every model's results go into a single transaction at the very end, after the reports have been generated and uploaded.

That leaves the connection idle for the whole run — and an idle connection is exactly what a firewall, a NAT or a restarted server drops. When that happened, the first `INSERT` at the end threw

```
psycopg2.OperationalError: server closed the connection unexpectedly
```

`test.py` died, and a night of testing was lost. Nothing looked wrong until that moment either: the heartbeat that holds the job claims opens a connection of its own every minute, so the claims kept being refreshed while the connection that mattered was already dead.

## What this does

- **Asks for TCP keepalives** (`keepalives=1 keepalives_idle=60 …`), so an idle connection is kept alive and a genuinely dead one is noticed early rather than at the end.
- **Reconnects and replays** if it is lost anyway: the statement that discovers the broken connection reconnects, replays the statements this transaction had written so far, and carries on.

Replaying is safe because of what #295 already put in place: everything a run writes is an insert guarded by a unique key — `(date, libname, model)` for a branch table — and the inserts use `ON CONFLICT DO NOTHING`. Replaying can only produce the rows that were lost, never a duplicate. Queries are not remembered, so the tens of thousands a run makes do not fill the buffer.

Nothing in `test.py` changes; the recovery lives in `resultsdb.py` and the sqlite3 backend is untouched.

## How it was checked

Against a real PostgreSQL, with a run's transaction half written, killing its backend the way a firewall would:

```
run's connection is backend 4117692
killing backend 4117692 after 250 rows...
  pg_terminate_backend -> t
Lost the connection to the database (SSL connection has been closed unexpectedly); reconnecting
Replayed 250 statements of the interrupted transaction
rows written: 500, rows in the database: 500 -> PASS
usable afterwards: PASS
```

Also, that the paths this must not disturb still work: a full `configs/sanityCheck.json` run on sqlite3 with the CI assertion passing, and a run against PostgreSQL with two FMI simulators filling `v1.27-fmi` and `v1.27-fmi-fmpy` and releasing its claim.

## What this is not

It makes losing the connection survivable; it does not make the results arrive any earlier. A run that is killed still loses everything it has tested, because it has written nothing yet.

Writing the results **per library, as each one finishes** — in the same transaction that marks that library's claim done — would fix that properly: a lost connection or a crash would then cost one library instead of a night, every library in the database would be whole rather than half-tested, and a rerun would resume where the last one stopped. It needs the results to be gathered per library rather than accumulated to the end, so it is worth doing as its own change.

---
Generated by Claude Code.
