### PR TITLE
Make the configuration hash the same on every machine

### DIFF
--- a/test.py
+++ b/test.py
@@ -605,6 +605,11 @@ for (library,conf) in configs:
   del(c["configFromFile"])
   if "referenceFiles" in c:
     del(c["referenceFilesURL"])
+    # Where the reference files happen to live on this machine must not go into
+    # the hash: their contents are hashed just below, and two machines sharing
+    # a database have to agree on what a configuration is. Each machine only
+    # ever had its own sqlite3 file before, so an absolute path was harmless.
+    c["referenceFiles"] = "referenceFiles"
     confighash = strToHashInt(str(c)+hashReferenceFiles(conf["referenceFiles"]))
   else:
     confighash = strToHashInt(str(c)+hashReferenceFiles(""))


### PR DESCRIPTION
Two machines running `master` at the same time both claimed the same 20 libraries and tested them twice, which is what #295 exists to prevent:

```
     host      | branch |  state  | count
---------------+--------+---------+-------
 ryzen-5950x-1 | master | running |    96
 ryzen-5950x-2 | master | running |    20

 libraries_claimed_by_both: 20
```

Not the compiler and not the library: both machines report `OMCompiler v1.28.0-dev.294+gce7a5ed7bc` and the same `libversion` (there had been no omc commit for seven hours). What differed was the **confighash**, which is part of the claim key `(branch, libname, libversion, omcversion, confighash)`:

```
ClaRa | ryzen-5950x-1 | 1.9.0 (https://github.com/xr... | 1132175474
ClaRa | ryzen-5950x-2 | 1.9.0 (https://github.com/xr... |  247072667
```

## Why

The hash is taken over the library's configuration, and by that point the configuration holds the reference files as an **absolute path**:

```python
destinationReal = os.path.realpath(destination)
c["referenceFiles"] = destinationReal
...
confighash = strToHashInt(str(c) + hashReferenceFiles(conf["referenceFiles"]))
```

So two machines whose workspaces sit in different places — or whose paths resolve through different symbolic links — hash an identical configuration differently.

This was harmless for as long as it existed: each machine had its own `sqlite3.db`, so the hash only ever had to be stable on the machine that produced it. Sharing one database is what made it matter, and it breaks two things at once:

- **the job claim does not exclude the other machine**, so both test the same library — the whole point of #295;
- **the "we already have results for it" check misses across machines**, so even a sequential run redoes work another machine has done.

## The fix

The path contributes nothing the hash needs. The *contents* of the reference files are hashed on the very next line by `hashReferenceFiles()`, and the same files in a different directory are the same test. So the path is replaced by a constant before hashing.

## Checked

The same configuration under two different reference directories:

```
before   machineA 3181697168  machineB 2732211752  -> DIFFERENT (both claim the library)
after    machineA 1884809167  machineB 1884809167  -> SAME (machines agree)
after    reference file changed          -> DIFFERENT (correct)
```

so the hash stops depending on where the files are while still depending on what is in them. Plus a full `configs/sanityCheck.json` run with the CI assertion passing.

## One deliberate consequence

Every `confighash` changes value once. The first run after this sees no matching rows and treats every library as untested, so it tests everything once. From then on the machines agree — and until then they duplicate work anyway, which is the bug.

---
Generated by Claude Code.
