### PR TITLE
Build the report image on the same base as OpenModelica

### DIFF
--- a/.CI/build-dep/Dockerfile
+++ b/.CI/build-dep/Dockerfile
@@ -1,4 +1,7 @@
-FROM docker.openmodelica.org/build-deps:v1.16.3
+# The image the OpenModelica repository builds against, see its .CI/common.groovy
+FROM docker.openmodelica.org/build-deps:ubuntu-22.04
 
-RUN apt-get update && apt-get install libxml2 libxslt1.1 libxml2-dev libxslt1-dev
+# -y because a base image that does not assume it turns the build into a prompt,
+# and python3-pip because the line below needs it and the base may not carry it.
+RUN apt-get update && apt-get install -y libxml2 libxslt1.1 libxml2-dev libxslt1-dev python3-pip
 RUN pip3 install matplotlib FMPy psycopg2-binary


### PR DESCRIPTION
The image the two report stages run in was still built on `build-deps:v1.16.3` — the dependency image of OpenModelica 1.16:

```dockerfile
FROM docker.openmodelica.org/build-deps:v1.16.3
```

It now uses `ubuntu-22.04`, which is what the OpenModelica repository itself builds against in `.CI/common.groovy` and in every cmake Jenkinsfile, so the reports run on the same Ubuntu and the same Python as everything else.

There is a practical reason too: `#296` added `psycopg2-binary` to that image for the results database. On a current base there is a wheel for it; on an old one pip falls back to building `psycopg2` from source, which needs `pg_config` out of `libpq-dev` and fails without it.

Two things the change stops assuming of the base image:

- **`apt-get install -y`** — an image that does not set `APT::Get::Assume-Yes` turns the build into a prompt nobody answers.
- **`python3-pip`** — the next line needs pip, and the base may not carry it.

## Not verified here

There is no docker on the machine I work from, so I could not build the image. What I did check is that `ubuntu-22.04` exists in the registry and is the tag the OpenModelica repository uses. The first report-stage build is the real test; if it fails it will be in the `pip3 install` step.

---
Generated by Claude Code.
