### PR TITLE
Test every library of an FMI job with FMI

### DIFF
--- a/test.py
+++ b/test.py
@@ -490,65 +490,65 @@ for (lib,c) in configs:
         refFilesGitTag = c["referenceFiles"]["git-ref"].strip()
         if not refFilesGitTag.startswith("origin/"):
           refFilesGitTag = 'origin/%s' % refFilesGitTag
-      if c["referenceFiles"]["destination"] in preparedReferenceDirs:
+      # Several libraries share one set of reference files. The first of them
+      # prepares the directory and the rest take what it recorded - but the rest
+      # of this loop still has to run for every one of them.
+      destination = os.path.normpath(c["referenceFiles"]["destination"])
+      if destination in preparedReferenceDirs:
         (c["referenceFiles"],c["referenceFilesURL"]) = preparedReferenceDirs[destination]
-        continue
-      giturl = c["referenceFiles"]["giturl"]
-      destination = c["referenceFiles"]["destination"]
-      if DEBUG:
-        print("destination %s" % destination)
-      destination = os.path.normpath(destination)
-      if DEBUG:
-        print("normalized destination %s" % destination)
-        print("not os.path.isdir(destination): %s" % (not os.path.isdir(destination)))
-      destinationReal = os.path.realpath(destination)
-      if DEBUG:
-        print("destinationReal %s" % destinationReal)
-      destinationReal = os.path.normpath(destinationReal)
-      if DEBUG:
-        print("normalized destinationReal %s" % destinationReal)
-        print("referenceFiles:", c["referenceFiles"])
+      else:
+        giturl = c["referenceFiles"]["giturl"]
+        if DEBUG:
+          print("destination %s" % destination)
+          print("not os.path.isdir(destination): %s" % (not os.path.isdir(destination)))
+        destinationReal = os.path.realpath(destination)
+        if DEBUG:
+          print("destinationReal %s" % destinationReal)
+        destinationReal = os.path.normpath(destinationReal)
+        if DEBUG:
+          print("normalized destinationReal %s" % destinationReal)
+          print("referenceFiles:", c["referenceFiles"])
 
-      if not os.path.isdir(destination):
+        if not os.path.isdir(destination):
+          if "git-directory" in c["referenceFiles"]:
+            # Sparse clone
+            os.makedirs(destination)
+            check_call_log(["git", "init"], stderr=subprocess.STDOUT, cwd=destinationReal)
+            check_call_log(["git", "remote", "add", "-f", "origin", giturl], stderr=subprocess.STDOUT, cwd=destinationReal)
+            check_call_log(["git", "config", "core.sparseCheckout", "true"], stderr=subprocess.STDOUT, cwd=destinationReal)
+            file = open(os.path.join(destinationReal,".git", "info", "sparse-checkout"), "a")
+            file.write(c["referenceFiles"]["git-directory"].strip())
+            file.close()
+          else:
+            # Clone
+            check_call_log(["git", "clone", giturl, destination], stderr=subprocess.STDOUT)
+
+        check_call_log(["git", "clean", "-fdx", "--exclude=*.hash"], stderr=subprocess.STDOUT, cwd=destinationReal)
+        check_call_log(["git", "fetch", "origin"], stderr=subprocess.STDOUT, cwd=destination)
+        # do not fail if the branch we were given doesn't exist
+        try:
+          check_call_log(["git", "reset", "--hard", refFilesGitTag], stderr=subprocess.STDOUT, cwd=destinationReal)
+        except subprocess.CalledProcessError as e:
+          print(e.output)
+        check_call_log(["git", "clean", "-fdx", "--exclude=*.hash"], stderr=subprocess.STDOUT, cwd=destinationReal)
+        if glob.glob(destinationReal + "/*.mat.xz"):
+          check_call_log(["find", ".", "-name", "*.mat.xz", "-exec", "xz", "--decompress", "--keep", "{}", ";"], stderr=subprocess.STDOUT, cwd=destinationReal)
+        try:
+          githash = check_output_log(["git", "rev-parse", "--verify", "HEAD"], stderr=subprocess.STDOUT, cwd=destinationReal, encoding='utf8')
+        except subprocess.CalledProcessError as e:
+          print(e.output)
+
         if "git-directory" in c["referenceFiles"]:
-          # Sparse clone
-          os.makedirs(destination)
-          check_call_log(["git", "init"], stderr=subprocess.STDOUT, cwd=destinationReal)
-          check_call_log(["git", "remote", "add", "-f", "origin", giturl], stderr=subprocess.STDOUT, cwd=destinationReal)
-          check_call_log(["git", "config", "core.sparseCheckout", "true"], stderr=subprocess.STDOUT, cwd=destinationReal)
-          file = open(os.path.join(destinationReal,".git", "info", "sparse-checkout"), "a")
-          file.write(c["referenceFiles"]["git-directory"].strip())
-          file.close()
+          c["referenceFiles"] = os.path.join(destinationReal, c["referenceFiles"]['git-directory'])
+          print(c["referenceFiles"])
         else:
-          # Clone
-          check_call_log(["git", "clone", giturl, destination], stderr=subprocess.STDOUT)
+          c["referenceFiles"] = destinationReal
 
-      check_call_log(["git", "clean", "-fdx", "--exclude=*.hash"], stderr=subprocess.STDOUT, cwd=destinationReal)
-      check_call_log(["git", "fetch", "origin"], stderr=subprocess.STDOUT, cwd=destination)
-      # do not fail if the branch we were given doesn't exist
-      try:
-        check_call_log(["git", "reset", "--hard", refFilesGitTag], stderr=subprocess.STDOUT, cwd=destinationReal)
-      except subprocess.CalledProcessError as e:
-        print(e.output)
-      check_call_log(["git", "clean", "-fdx", "--exclude=*.hash"], stderr=subprocess.STDOUT, cwd=destinationReal)
-      if glob.glob(destinationReal + "/*.mat.xz"):
-        check_call_log(["find", ".", "-name", "*.mat.xz", "-exec", "xz", "--decompress", "--keep", "{}", ";"], stderr=subprocess.STDOUT, cwd=destinationReal)
-      try:
-        githash = check_output_log(["git", "rev-parse", "--verify", "HEAD"], stderr=subprocess.STDOUT, cwd=destinationReal, encoding='utf8')
-      except subprocess.CalledProcessError as e:
-        print(e.output)
-
-      if "git-directory" in c["referenceFiles"]:
-        c["referenceFiles"] = os.path.join(destinationReal, c["referenceFiles"]['git-directory'])
-        print(c["referenceFiles"])
-      else:
-        c["referenceFiles"] = destinationReal
-
-      if giturl.startswith("https://github.com"):
-        c["referenceFilesURL"] = '<a href="%s/tree/%s">%s (%s)</a>' % (giturl, githash.strip(), giturl, githash.strip())
-      else:
-        c["referenceFilesURL"] = "%s (%s)" % (giturl, githash.strip())
-      preparedReferenceDirs[destination] = (c["referenceFiles"],c["referenceFilesURL"])
+        if giturl.startswith("https://github.com"):
+          c["referenceFilesURL"] = '<a href="%s/tree/%s">%s (%s)</a>' % (giturl, githash.strip(), giturl, githash.strip())
+        else:
+          c["referenceFilesURL"] = "%s (%s)" % (giturl, githash.strip())
+        preparedReferenceDirs[destination] = (c["referenceFiles"],c["referenceFilesURL"])
     else:
       raise Exception("Unknown referenceFiles in config: %s" % (str(c["referenceFiles"])))
 
@@ -952,6 +952,19 @@ if args.coldhot:
       print("  %-70s cold %8.4f  hot %8.4f" % (model, data["simcold"], data.get("sim") or 0.0))
   sys.stdout.flush()
 
+BUILD_PHASE = 5
+"""The last phase a model shares with every simulator of its FMU."""
+
+def phaseWithoutSimulator(data):
+  """How far a model got for a simulator that never ran it.
+
+  Everything up to the build is shared, so such a model reports the phase the
+  build reached and never the phase another simulator went on to reach with the
+  same FMU. Reporting that one would claim a simulation, and a verification,
+  that this simulator never performed.
+  """
+  return min(data.get("phase") or 0, BUILD_PHASE)
+
 def resultValues(model, libname, data, simulator=None):
   """One row of a branch table.
 
@@ -961,9 +974,7 @@ def resultValues(model, libname, data, simulator=None):
   """
   simulated = data if simulator is None else (data.get("simulators") or {}).get(simulator)
   if simulated is None:
-    # The model never got as far as being simulated, so every simulator of it
-    # reports the phase the build stopped at rather than a failure of its own.
-    simulated = {"phase": data.get("phase") or 0}
+    simulated = {"phase": phaseWithoutSimulator(data)}
   diff = simulated.get("diff") or {}
   return (testRunStartTimeAsEpoch,
     libname,
@@ -1095,7 +1106,7 @@ def dataForSimulator(data, simulator):
   merged["diff"] = (simulated or {}).get("diff")
   # A model that never got as far as being simulated stopped in the build,
   # which every simulator of it shares.
-  merged["phase"] = simulated.get("phase") if simulated else data.get("phase")
+  merged["phase"] = simulated.get("phase") if simulated is not None else phaseWithoutSimulator(data)
   return merged
 
 def artifactSuffix(simulator):
@@ -1155,7 +1166,9 @@ for (resultBranch, simulator) in resultBranches:
         ('<a href="%s">%s</a>' % (errPrefix + ".err", html.escape(s[1]))) if is_non_zero_file(errPrefix + ".err") else html.escape(s[1]),
         (' (<a href="%s">sim</a>)' % (filename_prefix + ".sim")) if is_non_zero_file(filename_prefix + suffix + ".sim") else "",
         checkPhase(s[3]["phase"], 7) if s[3]["phase"]>=6 else "#FFFFFF",
-        ("%s (%d verified)" % (timeSeconds(diff.get("time")), diff.get("numCompared"))) if s[3]["phase"]>=7 else ("&nbsp;" if diff is None else
+        # Nothing was compared, whatever phase the model reports.
+        "&nbsp;" if diff is None else
+        (("%s (%d verified)" % (timeSeconds(diff.get("time")), diff.get("numCompared"))) if s[3]["phase"]>=7 else
         ('%s (<a href="%s.diff.html">%d/%d failed</a>)' % (timeSeconds(diff.get("time")), filename_prefix, len(diff.get("vars")), diff.get("numCompared")))),
         checkPhase(s[3]["phase"], 6),
         timeSeconds(s[3].get("sim") or 0),


### PR DESCRIPTION
The `master-fmi` job of [build 11369](https://test.openmodelica.org/jenkins/job/LibraryTesting/job/LibraryTest/11369/console) ran for seven hours and twenty minutes and then threw all of it away:

```
Traceback (most recent call last):
  File "./test.py", line 1153, in <module>
    (lambda filename_prefix, errPrefix, diff:
  File "./test.py", line 1158, in <lambda>
    ("%s (%d verified)" % (timeSeconds(diff.get("time")), diff.get("numCompared"))) if s[3]["phase"]>=7 else (...
AttributeError: 'NoneType' object has no attribute 'get'
```

A model reported that it had been verified while having nothing to show for the comparison. Chasing that turned up an older bug underneath it.

## Four libraries have not been testing FMI at all

The configuration loop prepares a reference-file directory once and lets the libraries that share it reuse the result:

```python
if c["referenceFiles"]["destination"] in preparedReferenceDirs:
  (c["referenceFiles"],c["referenceFilesURL"]) = preparedReferenceDirs[destination]
  continue
```

That `continue` skips the rest of the loop body — and the only thing after it is the line that turns FMI on:

```python
if allTestsFmi:
  c["fmi"] = "2.0"
```

So in `configs/conf.json` four libraries have been running as ordinary native models inside the FMI jobs, each of them the second library to want a directory another had already cloned:

| library | shares the reference files of |
| --- | --- |
| `PowerGrids_symb_jac` | `PowerGrids` |
| `PowerGrids_dev` | `PowerGrids` |
| `ClaRa_dev` | `ClaRa` |
| `ScalableTestSuite_noopt` | `ScalableTestSuite` |

The results say so plainly. Each of the four verifies exactly the same number of models in `master` and in `master-fmi`, while every library that prepares its own directory drops as an FMI job should:

| library | master | master-fmi | |
| --- | --- | --- | --- |
| `PowerGrids_symb_jac` | 66 | 66 | never built an FMU |
| `PowerGrids_dev` | 19 | 19 | never built an FMU |
| `ClaRa_dev` | 72 | 72 | never built an FMU |
| `ScalableTestSuite_noopt` | 244 | 244 | never built an FMU |
| `PowerGrids` | 65 | 31 | |
| `ScalableTestSuite` | 242 | 176 | |
| `ClaRa` | 72 | 62 | |

The same three lines also looked the directory up under `destination` — a variable assigned *after* the lookup, so it held whatever the previous library left behind. It has been reading the right entry only because every `destination` in the configuration happens to be spelled in normalised form.

Both are fixed by computing the normalised destination first and putting the preparation in an `else` branch, so nothing in the loop body is unreachable any more.

## Why it started crashing

Before #297 this only mistested those libraries quietly. Now a job can run several simulators against one FMU, and a model that was never built as an FMU has no per-simulator results at all — so the second simulator's branch fell back to the phase the **first** simulator reached. That is 7, verified, with no comparison to go with it, and the report generator trusts `phase >= 7` to mean there is one.

Two changes:

- a simulator that never ran a model now reports the phase the **shared build** reached, never a phase another simulator went on to reach with the same FMU. The database row and the report agree, because both go through the same helper.
- a model with nothing to compare renders as an empty cell whatever phase it claims. A mismatch should not be able to throw away a finished run.

## Testing

The report cell was evaluated directly, before and after, by extracting the real expression from `test.py`:

```
before   diff=None, phase=7 -> AttributeError: 'NoneType' object has no attribute 'get'
before   verified          -> '1.50 (12 verified)'
before   failed vars       -> '1.50 (<a href="files/L_M.diff.html">2/12 failed</a>)'
after    diff=None, phase=7 -> '&nbsp;'
after    verified          -> '1.50 (12 verified)'
after    failed vars       -> '1.50 (<a href="files/L_M.diff.html">2/12 failed</a>)'
```

The reference-file loop was executed as it stands, with git and omc stubbed, over three libraries sharing one directory. Before, the third lost `fmi`; after, all three keep it, and each still ends up with the same prepared reference files.

`resultValues` and `dataForSimulator` were exercised over the shapes that matter: a simulator with no results of its own (phase capped at the build, no diff, no simulation time, and the row records the same), a build that failed (keeps its own lower phase), a simulator with its own results (untouched), one that ran and failed (reports its own failure, not the other's success), and the primary branch (passed through unchanged).

Related to #297, which turned this from a silent mistest into a crash.

---
Generated by Claude Code.
