### PR TITLE
Record what a command killed by the watchdog cost

### DIFF
--- a/testmodel.py
+++ b/testmodel.py
@@ -50,7 +50,29 @@ except OSError:
 class TimeoutError(Exception):
   pass
 
+runningPhase = None
+"""What is running now, as (key of execstat, when it started).
+
+A command the watchdog has to kill never returns to its caller -
+sendExpressionTimeout ends the process itself - so the caller's own timeout
+handler does not run and the phase reports no time at all. Recording it here
+instead covers every way out, because they all write the results first.
+"""
+
+def phaseStarts(key):
+  global runningPhase
+  runningPhase = (key, monotonic())
+
+def phaseEnded():
+  global runningPhase
+  runningPhase = None
+
 def writeResult():
+  if runningPhase is not None:
+    (key, started) = runningPhase
+    # Only if the phase did not get to report its own time.
+    if not execstat.get(key):
+      execstat[key] = monotonic() - started
   with open(statFile, 'w') as fp:
     json.dump(execstat, fp)
     fp.flush()
@@ -447,19 +469,28 @@ def simulateCmd(resimulate):
 total_before = omc.sendExpression("OpenModelica.Scripting.Internal.Time.timerTock(OpenModelica.Scripting.Internal.Time.RT_CLOCK_SIMULATE_TOTAL)")
 start=monotonic()
 timeout = conf["ulimitOmc"]
+# If the command has to be killed there is no way to tell which phase it was in,
+# so its time is charged to what the command itself is: building an FMU to the
+# build, simulating to the simulation, translating to the front end - which is
+# also the phase such a model is reported as having failed in.
 if conf.get("fmi"):
   cmd='"" <> buildModelFMU(%s,fileNamePrefix="%s",fmuType="%s",version="%s",platforms={"static"})' % (conf["modelName"],conf["fileName"].replace(".","_"),conf["fmuType"],conf["fmi"])
+  timedPhase = "build"
 elif useSimulate:
   cmd=simulateCmd(resimulate=False)
   timeout = conf["ulimitOmc"] + conf["ulimitExe"]
+  timedPhase = "sim"
 else:
   cmd='translateModel(%s,tolerance=%g,outputFormat="%s",numberOfIntervals=%d,variableFilter="%s",fileNamePrefix="%s")' % (conf["modelName"],tolerance,outputFormat,numberOfIntervals,variableFilter,conf["fileName"])
+  timedPhase = "frontend"
 with open(errFile, 'a+') as fp:
   fp.write("Running command: %s\n"%(cmd))
 try:
+  phaseStarts(timedPhase)
   res=sendExpressionTimeout(omc, cmd, timeout)
+  phaseEnded()
 except TimeoutError as e:
-  execstat["frontend"]=monotonic()-start
+  execstat[timedPhase]=monotonic()-start
 
   with open(errFile, 'a+') as fp:
     fp.write("Timeout error for cmd: %s\n%s"%(cmd,str(e)))


### PR DESCRIPTION
A model whose command runs out of time reports **nothing** for the phase it was in. The time only survives in `exectime`, and no report shows `exectime` per phase, so it vanishes.

In the `master` run of 2026-08-12 that is **15 models and 1.34 hours**. Three of them are `BuildingSystems` models that spend the full 660 second `ulimitOmc` budget inside `translateModel` and are recorded like this:

```
model                                                total  parse  fe  be  sc  tpl  comp  finalphase
BuildingSystems.Buildings.Zones.Examples.SingleZo...   666      3   0   0   0    0     0           0
```

Eleven minutes, of which three seconds are accounted for.

## Why

The caller does try to account for it:

```python
except TimeoutError as e:
  execstat["frontend"]=monotonic()-start
```

That handler never runs. `sendExpressionTimeout` kills the command and calls `writeResultAndExit` **itself, from inside**, before raising anything:

```python
with open(errFile, 'a+') as fp:
  fp.write("Aborted the command.\n")
writeResultAndExit(0, True, omc, omc_new)
```

So the process is gone before the exception reaches the caller, and the results written are whatever `execstat` held when the command started. The same applies to the path where omc dies mid-command.

## The change

Recording it where the results are written covers every way out, rather than the one path that remembered to. A phase says when it started, `writeResult` charges it if it never reported a time of its own, and a phase that ends normally still reports exactly what it did before:

```python
def writeResult():
  if runningPhase is not None:
    (key, started) = runningPhase
    # Only if the phase did not get to report its own time.
    if not execstat.get(key):
      execstat[key] = monotonic() - started
```

Which phase a killed command belongs to cannot be known — omc's timers die with it — so it is charged to what the command itself is: building an FMU to the build, simulating to the simulation, translating to the front end. That last one is also the phase such a model is reported as having failed in, so the row stays self-consistent.

## Testing

`Modelica.Fluid.Examples.HeatExchanger.HeatExchangerSimulation` with `ulimitOmc=1`, which the watchdog kills (`Thread is still alive. / Aborted the command.`):

```
before   {'parsing': 1.73}
after    {'parsing': 1.65, 'frontend': 3.01}
```

`Modelica.Blocks.Examples.PID_Controller`, which succeeds, is unchanged:

```
before   {'parsing': 1.69, 'frontend': 0.02, 'backend': 0.06, 'simcode': 0.01, 'templates': 0.09, 'build': 2.08, 'sim': 0.15, 'phase': 6}
after    {'parsing': 1.76, 'frontend': 0.02, 'backend': 0.05, 'simcode': 0.01, 'templates': 0.09, 'build': 1.99, 'sim': 0.17, 'phase': 6}
```

Both run against the real `testmodel.py` of this branch and of `origin/master`, on the same configuration.

## Scope

This is the part of #308 that is a genuine defect. The rest of that issue's description was wrong and is [corrected in a comment there](https://github.com/OpenModelica/OpenModelicaLibraryTesting/issues/308#issuecomment-5269297207): ordinary failures do record the phase they failed in — 851 of 867 front end failures and all 301 back end failures carry a time — and the remaining unattributed hours are about 0.7 s per model of process startup and teardown, which belongs to no phase because it is not one.

Part of #308.

---
Generated by Claude Code.
