### PR TITLE
Merge report stages and add wasm-jit to history/overview

### DIFF
--- a/.CI/Jenkinsfile
+++ b/.CI/Jenkinsfile
@@ -427,177 +427,128 @@ pipeline {
         }
       }
     } }
-    stage('report') { parallel {
-      stage('ryzen-5950x-1') {
-        agent {
-          dockerfile {
-            label 'linux'
-            dir '.CI/build-dep'
-            customWorkspace 'ws/OpenModelicaLibraryTestingReport'
-            args '-e IDA_EMAIL_USR=$IDA_EMAIL_USR -e IDA_EMAIL_PSW=$IDA_EMAIL_PSW'
-          }
-        }
-        when {
-          beforeAgent true
-          expression { params.v1_25 || params.v1_26 || params.v1_27 || params.master || params.conversion_script || params.report_ryzen_5950x_1 || params.newInst_newBackend || params.generateSymbolicJacobian || params.heavy_tests}
-        }
-        environment {
-          GITBRANCHES = 'maintenance/v1.20 maintenance/v1.21 maintenance/v1.22 maintenance/v1.23 maintenance/v1.24 maintenance/v1.25 maintenance/v1.26 maintenance/v1.27 master newInst-newBackend'
-          PYTHONIOENCODING = 'utf-8'
-          IDA_EMAIL = credentials('IDA email')
-          // A secret file holding one pgpass line; libpq reads the password from
-          // it, so it never reaches a command line or the build log. It is bound
-          // per stage because writing the file needs the workspace of a node,
-          // which the pipeline as a whole does not have (agent none).
-          PGPASSFILE = credentials('omdb-pgpass')
-        }
-        steps {
-          //sshagent (credentials: ['Hudson-SSH-Key']) {
-          //  createInitialHistoryFilesOnRemote()
-          //}
-          sh 'rm -rf *.html history'
-          sh '''
-          if ! test -d OpenModelica; then
-            git clone https://openmodelica.org/git-readonly/OpenModelica.git
-          fi
-          cd OpenModelica
-          git fetch
-          '''
-          sh './clean-empty-omcversion-dates.py'
-
-          sh "./all-reports.py --email --omcgitdir=OpenModelica ${env.GITBRANCHES} conversion heavy_tests"
-          sh "./all-plots.py ${env.GITBRANCHES}"
-
-          sh "./report.py --branches='${env.GITBRANCHES}' configs/conf.json configs/conf-old.json configs/conf-nonstandard.json"
-          sh 'mv overview.html overview-combined.html'
-          sh "./report.py --branches='${env.GITBRANCHES}' configs/conf-old.json"
-          sh "mv overview.html overview-old-libs.html"
-          sh "./report.py --branches='${env.GITBRANCHES}' configs/conf-nonstandard.json"
-          sh "mv overview.html overview-nonstandard-libs.html"
-          sh "./report.py --branches='master conversion' configs/conf.json"
-          sh "mv overview.html overview-special-jobs.html"
-
-          sh "./report.py --branches='generateSymbolicJacobian' configs/conf.json"
-          sh "mv overview.html overview-generateSymbolicJacobian.html"
-
-          sh "./report.py --branches='heavy_tests' configs/heavy_tests.json"
-          sh "mv overview.html overview-heavy_tests.html"
-
-          sh "./report.py --branches='${env.GITBRANCHES}' configs/conf.json"
-
-          sh 'date'
-          sh 'find overview*.html history -type f | wc -l'
-          sh 'find overview*.html history'
-
-          sshPublisher(publishers: [sshPublisherDesc(configName: 'LibraryTestingReports', transfers: [sshTransfer(sourceFiles: 'overview*.html,history/**')])])
-
+    stage('report') {
+      agent {
+        dockerfile {
+          label 'linux'
+          dir '.CI/build-dep'
+          customWorkspace 'ws/OpenModelicaLibraryTestingReport'
+          args '-e IDA_EMAIL_USR=$IDA_EMAIL_USR -e IDA_EMAIL_PSW=$IDA_EMAIL_PSW'
         }
       }
-
-      stage('ryzen-5950x-2') {
-        agent {
-          dockerfile {
-            label 'linux'
-            dir '.CI/build-dep'
-            customWorkspace 'ws/OpenModelicaLibraryTestingReport'
-            args '-e IDA_EMAIL_USR=$IDA_EMAIL_USR -e IDA_EMAIL_PSW=$IDA_EMAIL_PSW'
-          }
-        }
-        when {
-          beforeAgent true
-          expression { params.fmi_v1_25 || params.fmi_v1_26 || params.fmi_v1_27 || params.fmi_master || params.fmpy_fmi_v1_25 || params.fmpy_fmi_v1_26 || params.fmpy_fmi_v1_27 || params.fmpy_fmi_master || params.newInst_daeMode || params.newBackend_daeMode || params.oldInst || params.report_ryzen_5950x_2 || params.cpp || params.cvode || params.gbode || params.ida || params.wasm_jit}
-        }
-        environment {
-          GITBRANCHES_FMI = 'maintenance/v1.20-fmi maintenance/v1.21-fmi maintenance/v1.22-fmi maintenance/v1.23-fmi maintenance/v1.24-fmi maintenance/v1.25-fmi maintenance/v1.26-fmi maintenance/v1.27-fmi maintenance/v1.22-fmi-fmpy maintenance/v1.23-fmi-fmpy maintenance/v1.24-fmi-fmpy maintenance/v1.25-fmi-fmpy maintenance/v1.26-fmi-fmpy maintenance/v1.27-fmi-fmpy master-fmi master-fmi-fmpy'
-          GITBRANCHES_NEWINST = 'oldInst'
-          GITBRANCHES_DAE = 'newInst-daeMode'
-          GITBRANCHES_NEWBACKEND_DAE = 'newBackend-daeMode'
-          GITBRANCHES_CPP = 'v1.19-cpp v1.20-cpp v1.21-cpp v1.22-cpp v1.23-cpp v1.24-cpp v1.25-cpp cpp v1.26-cpp v1.27-cpp'
-          PYTHONIOENCODING = 'utf-8'
-          IDA_EMAIL = credentials('IDA email')
-          // A secret file holding one pgpass line; libpq reads the password from
-          // it, so it never reaches a command line or the build log. It is bound
-          // per stage because writing the file needs the workspace of a node,
-          // which the pipeline as a whole does not have (agent none).
-          PGPASSFILE = credentials('omdb-pgpass')
-        }
-        steps {
-          //sshagent (credentials: ['Hudson-SSH-Key']) {
-          //  createInitialHistoryFilesOnRemote()
-          //}
-          sh 'rm -f *.html'
-          sh '''
-          if ! test -d OpenModelica; then
-            git clone https://openmodelica.org/git-readonly/OpenModelica.git
-          fi
-          cd OpenModelica
-          git fetch
-          '''
-          sh './clean-empty-omcversion-dates.py'
-
-          sh "./all-reports.py --email --omcgitdir=OpenModelica ${env.GITBRANCHES_FMI} ${env.GITBRANCHES_NEWINST} ${env.GITBRANCHES_DAE} ${env.GITBRANCHES_NEWBACKEND_DAE} ${env.GITBRANCHES_CPP} gbode cvode ida"
-          sh "./all-plots.py ${env.GITBRANCHES_FMI} ${env.GITBRANCHES_NEWINST} ${env.GITBRANCHES_DAE} ${env.GITBRANCHES_NEWBACKEND_DAE} ${env.GITBRANCHES_CPP} gbode cvode ida"
-
-          sh "./report.py --branches='${env.GITBRANCHES_NEWINST}' configs/conf.json"
-          sh "mv overview.html overview-oldinst.html"
-          sh "./report.py --branches='${env.GITBRANCHES_NEWINST}' configs/conf.json configs/conf-old.json configs/conf-nonstandard.json"
-          sh "mv overview.html overview-combined-oldinst.html"
-          sh "./report.py --branches='${env.GITBRANCHES_NEWINST}' configs/conf-old.json"
-          sh "mv overview.html overview-old-libs-oldinst.html"
-          sh "./report.py --branches='${env.GITBRANCHES_NEWINST}' configs/conf-nonstandard.json"
-          sh "mv overview.html overview-nonstandard-libs-oldinst.html"
-
-          sh "./report.py --branches='${env.GITBRANCHES_FMI}' configs/conf.json"
-          sh "mv overview.html overview-fmi.html"
-          sh "./report.py --branches='${env.GITBRANCHES_FMI}' configs/conf.json configs/conf-old.json configs/conf-nonstandard.json"
-          sh "mv overview.html overview-combined-fmi.html"
-          sh "./report.py --branches='${env.GITBRANCHES_FMI}' configs/conf-old.json"
-          sh "mv overview.html overview-old-libs-fmi.html"
-          sh "./report.py --branches='${env.GITBRANCHES_FMI}' configs/conf-nonstandard.json"
-          sh "mv overview.html overview-nonstandard-libs-fmi.html"
-
-          sh "./report.py --branches='${env.GITBRANCHES_DAE}' configs/conf.json"
-          sh "mv overview.html overview-dae.html"
-          sh "./report.py --branches='${env.GITBRANCHES_DAE}' configs/conf.json configs/conf-old.json  configs/conf-nonstandard.json"
-          sh "mv overview.html overview-combined-dae.html"
-          sh "./report.py --branches='${env.GITBRANCHES_DAE}' configs/conf-old.json"
-          sh "mv overview.html overview-old-libs-dae.html"
-          sh "./report.py --branches='${env.GITBRANCHES_DAE}' configs/conf-nonstandard.json"
-          sh "mv overview.html overview-nonstandard-libs-dae.html"
-
-          sh "./report.py --branches='${env.GITBRANCHES_NEWBACKEND_DAE}' configs/conf.json"
-          sh "mv overview.html overview-newbackend-dae.html"
-          sh "./report.py --branches='${env.GITBRANCHES_NEWBACKEND_DAE}' configs/conf.json configs/conf-old.json configs/conf-nonstandard.json"
-          sh "mv overview.html overview-combined-newbackend-dae.html"
-          sh "./report.py --branches='${env.GITBRANCHES_NEWBACKEND_DAE}' configs/conf-old.json"
-          sh "mv overview.html overview-old-libs-newbackend-dae.html"
-          sh "./report.py --branches='${env.GITBRANCHES_NEWBACKEND_DAE}' configs/conf-nonstandard.json"
-          sh "mv overview.html overview-nonstandard-libs-newbackend-dae.html"
-
-          sh "./report.py --branches='cvode' configs/conf.json"
-          sh "mv overview.html overview-cvode.html"
-
-          sh "./report.py --branches='gbode' configs/conf.json"
-          sh "mv overview.html overview-gbode.html"
-
-          sh "./report.py --branches='ida' configs/conf.json"
-          sh "mv overview.html overview-ida.html"
-
-          sh "./report.py --branches='wasm-jit' configs/conf.json"
-          sh "mv overview.html overview-wasm-jit.html"
-
-          sh "./report.py --branches='${env.GITBRANCHES_CPP}' configs/conf.json"
-          sh "mv overview.html overview-c++.html"
-
-          sh 'date'
-          sh 'find overview*.html history -type f | wc -l'
-          sh 'find overview*.html history'
-
-          sshPublisher(publishers: [sshPublisherDesc(configName: 'LibraryTestingReports', transfers: [sshTransfer(sourceFiles: 'overview-*.html,history/**')])])
-
-        }
+      when {
+        beforeAgent true
+        expression { params.v1_25 || params.v1_26 || params.v1_27 || params.master || params.conversion_script || params.report_ryzen_5950x_1 || params.report_ryzen_5950x_2 || params.newInst_newBackend || params.generateSymbolicJacobian || params.heavy_tests || params.fmi_v1_25 || params.fmi_v1_26 || params.fmi_v1_27 || params.fmi_master || params.fmpy_fmi_v1_25 || params.fmpy_fmi_v1_26 || params.fmpy_fmi_v1_27 || params.fmpy_fmi_master || params.newInst_daeMode || params.newBackend_daeMode || params.oldInst || params.cpp || params.cvode || params.gbode || params.ida || params.wasm_jit}
       }
-    } }
+      environment {
+        GITBRANCHES = 'maintenance/v1.20 maintenance/v1.21 maintenance/v1.22 maintenance/v1.23 maintenance/v1.24 maintenance/v1.25 maintenance/v1.26 maintenance/v1.27 master newInst-newBackend'
+        GITBRANCHES_FMI = 'maintenance/v1.20-fmi maintenance/v1.21-fmi maintenance/v1.22-fmi maintenance/v1.23-fmi maintenance/v1.24-fmi maintenance/v1.25-fmi maintenance/v1.26-fmi maintenance/v1.27-fmi maintenance/v1.22-fmi-fmpy maintenance/v1.23-fmi-fmpy maintenance/v1.24-fmi-fmpy maintenance/v1.25-fmi-fmpy maintenance/v1.26-fmi-fmpy maintenance/v1.27-fmi-fmpy master-fmi master-fmi-fmpy'
+        GITBRANCHES_NEWINST = 'oldInst'
+        GITBRANCHES_DAE = 'newInst-daeMode'
+        GITBRANCHES_NEWBACKEND_DAE = 'newBackend-daeMode'
+        GITBRANCHES_CPP = 'v1.19-cpp v1.20-cpp v1.21-cpp v1.22-cpp v1.23-cpp v1.24-cpp v1.25-cpp cpp v1.26-cpp v1.27-cpp'
+        GITBRANCHES_WASM_JIT = 'wasm-jit'
+        GITBRANCHES_SPECIAL = 'master wasm-jit newInst-newBackend'
+        PYTHONIOENCODING = 'utf-8'
+        IDA_EMAIL = credentials('IDA email')
+        // A secret file holding one pgpass line; libpq reads the password from
+        // it, so it never reaches a command line or the build log. It is bound
+        // per stage because writing the file needs the workspace of a node,
+        // which the pipeline as a whole does not have (agent none).
+        PGPASSFILE = credentials('omdb-pgpass')
+      }
+      steps {
+        //sshagent (credentials: ['Hudson-SSH-Key']) {
+        //  createInitialHistoryFilesOnRemote()
+        //}
+        sh 'rm -rf *.html history'
+        sh '''
+        if ! test -d OpenModelica; then
+          git clone https://openmodelica.org/git-readonly/OpenModelica.git
+        fi
+        cd OpenModelica
+        git fetch
+        '''
+        sh './clean-empty-omcversion-dates.py'
+
+        sh "./all-reports.py --email --omcgitdir=OpenModelica ${env.GITBRANCHES} ${env.GITBRANCHES_FMI} ${env.GITBRANCHES_NEWINST} ${env.GITBRANCHES_DAE} ${env.GITBRANCHES_NEWBACKEND_DAE} ${env.GITBRANCHES_CPP} ${env.GITBRANCHES_WASM_JIT} conversion heavy_tests generateSymbolicJacobian gbode cvode ida"
+        sh "./all-plots.py ${env.GITBRANCHES} ${env.GITBRANCHES_FMI} ${env.GITBRANCHES_NEWINST} ${env.GITBRANCHES_DAE} ${env.GITBRANCHES_NEWBACKEND_DAE} ${env.GITBRANCHES_CPP} ${env.GITBRANCHES_WASM_JIT} conversion heavy_tests generateSymbolicJacobian gbode cvode ida"
+
+        sh "./report.py --branches='${env.GITBRANCHES} ${env.GITBRANCHES_WASM_JIT}' configs/conf.json configs/conf-old.json configs/conf-nonstandard.json"
+        sh 'mv overview.html overview-combined.html'
+        sh "./report.py --branches='${env.GITBRANCHES} ${env.GITBRANCHES_WASM_JIT}' configs/conf-old.json"
+        sh "mv overview.html overview-old-libs.html"
+        sh "./report.py --branches='${env.GITBRANCHES} ${env.GITBRANCHES_WASM_JIT}' configs/conf-nonstandard.json"
+        sh "mv overview.html overview-nonstandard-libs.html"
+        sh "./report.py --branches='${env.GITBRANCHES_SPECIAL} conversion' configs/conf.json"
+        sh "mv overview.html overview-special-jobs.html"
+
+        sh "./report.py --branches='generateSymbolicJacobian' configs/conf.json"
+        sh "mv overview.html overview-generateSymbolicJacobian.html"
+
+        sh "./report.py --branches='heavy_tests' configs/heavy_tests.json"
+        sh "mv overview.html overview-heavy_tests.html"
+
+        sh "./report.py --branches='${env.GITBRANCHES_NEWINST}' configs/conf.json"
+        sh "mv overview.html overview-oldinst.html"
+        sh "./report.py --branches='${env.GITBRANCHES_NEWINST}' configs/conf.json configs/conf-old.json configs/conf-nonstandard.json"
+        sh "mv overview.html overview-combined-oldinst.html"
+        sh "./report.py --branches='${env.GITBRANCHES_NEWINST}' configs/conf-old.json"
+        sh "mv overview.html overview-old-libs-oldinst.html"
+        sh "./report.py --branches='${env.GITBRANCHES_NEWINST}' configs/conf-nonstandard.json"
+        sh "mv overview.html overview-nonstandard-libs-oldinst.html"
+
+        sh "./report.py --branches='${env.GITBRANCHES_FMI}' configs/conf.json"
+        sh "mv overview.html overview-fmi.html"
+        sh "./report.py --branches='${env.GITBRANCHES_FMI}' configs/conf.json configs/conf-old.json configs/conf-nonstandard.json"
+        sh "mv overview.html overview-combined-fmi.html"
+        sh "./report.py --branches='${env.GITBRANCHES_FMI}' configs/conf-old.json"
+        sh "mv overview.html overview-old-libs-fmi.html"
+        sh "./report.py --branches='${env.GITBRANCHES_FMI}' configs/conf-nonstandard.json"
+        sh "mv overview.html overview-nonstandard-libs-fmi.html"
+
+        sh "./report.py --branches='${env.GITBRANCHES_DAE}' configs/conf.json"
+        sh "mv overview.html overview-dae.html"
+        sh "./report.py --branches='${env.GITBRANCHES_DAE}' configs/conf.json configs/conf-old.json configs/conf-nonstandard.json"
+        sh "mv overview.html overview-combined-dae.html"
+        sh "./report.py --branches='${env.GITBRANCHES_DAE}' configs/conf-old.json"
+        sh "mv overview.html overview-old-libs-dae.html"
+        sh "./report.py --branches='${env.GITBRANCHES_DAE}' configs/conf-nonstandard.json"
+        sh "mv overview.html overview-nonstandard-libs-dae.html"
+
+        sh "./report.py --branches='${env.GITBRANCHES_NEWBACKEND_DAE}' configs/conf.json"
+        sh "mv overview.html overview-newbackend-dae.html"
+        sh "./report.py --branches='${env.GITBRANCHES_NEWBACKEND_DAE}' configs/conf.json configs/conf-old.json configs/conf-nonstandard.json"
+        sh "mv overview.html overview-combined-newbackend-dae.html"
+        sh "./report.py --branches='${env.GITBRANCHES_NEWBACKEND_DAE}' configs/conf-old.json"
+        sh "mv overview.html overview-old-libs-newbackend-dae.html"
+        sh "./report.py --branches='${env.GITBRANCHES_NEWBACKEND_DAE}' configs/conf-nonstandard.json"
+        sh "mv overview.html overview-nonstandard-libs-newbackend-dae.html"
+
+        sh "./report.py --branches='cvode master' configs/conf.json"
+        sh "mv overview.html overview-cvode.html"
+
+        sh "./report.py --branches='gbode master' configs/conf.json"
+        sh "mv overview.html overview-gbode.html"
+
+        sh "./report.py --branches='ida master' configs/conf.json"
+        sh "mv overview.html overview-ida.html"
+
+        sh "./report.py --branches='wasm-jit master' configs/conf.json"
+        sh "mv overview.html overview-wasm-jit.html"
+
+        sh "./report.py --branches='${env.GITBRANCHES_CPP}' configs/conf.json"
+        sh "mv overview.html overview-c++.html"
+
+        sh "./report.py --branches='${env.GITBRANCHES}' configs/conf.json"
+
+        sh 'date'
+        sh 'find overview*.html history -type f | wc -l'
+        sh 'find overview*.html history'
+
+        sshPublisher(publishers: [sshPublisherDesc(configName: 'LibraryTestingReports', transfers: [sshTransfer(sourceFiles: 'overview*.html,history/**')])])
+      }
+    }
   }
 }
 def omsimulatorHash() {
@@ -633,7 +584,7 @@ HISTORY_DIRECTORY='/var/www/libraries.openmodelica.org/branches/history/'
 SEPARATOR='/'
 HISTORY_FILE='00_history.html'
 
-for b in ${env.GITBRANCHES} ${env.GITBRANCHES_FMI} ${env.GITBRANCHES_NEWINST} ${env.GITBRANCHES_DAE} ${env.GITBRANCHES_CPP}; do
+for b in ${env.GITBRANCHES} ${env.GITBRANCHES_FMI} ${env.GITBRANCHES_NEWINST} ${env.GITBRANCHES_DAE} ${env.GITBRANCHES_CPP} ${env.GITBRANCHES_WASM_JIT}; do
  BRANCH=`echo \${b} | cut -d '/' -f2`
  FILE="\${HISTORY_DIRECTORY}\${BRANCH}\${SEPARATOR}\${HISTORY_FILE}"
 ssh hudson@build.openmodelica.org << EOF


### PR DESCRIPTION
- Merge ryzen-5950x-1 and ryzen-5950x-2 report stages into a single stage (Postgres makes this fast)

- Add wasm-jit to all-reports.py/all-plots.py so history reports are generated for it

- Include wasm-jit in overview-combined.html and overview-special-jobs.html alongside master and newInst-newBackend