### PR TITLE
Strip -rust suffix from version for git range queries

### DIFF
--- a/all-reports.py
+++ b/all-reports.py
@@ -56,6 +56,7 @@ def dateStr(dint):
 
 def getTagOrVersion(v):
   v = v.replace("OpenModelica ","").replace("OMCompiler ","")
+  v = re.sub(r"-rust$", "", v)
   m = re.search("[+]g([0-9a-f]{7}[0-9a-f]*)$", v)
   if m:
     return m.group(1)


### PR DESCRIPTION
The all-reports script uses omcversion from the database to build git range specs like 'v1..v2' for commit log lookups.  Rust builds append '-rust' to the version (e.g. 'v1.28.0-dev-308-g1ac9d5ad20-rust') which git cannot resolve as a tag or ref.

Strip the trailing '-rust' before the version is used in git commands so the underlying tag (e.g. 'v1.28.0-dev-308-g1ac9d5ad20') is found.