### PR TITLE
Install jinja2 in wasm-jit image for Buildings library

### DIFF
--- a/.CI/wasm-jit/Dockerfile
+++ b/.CI/wasm-jit/Dockerfile
@@ -15,6 +15,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 COPY requirements.txt /tmp/requirements.txt
 RUN python3 -m venv /opt/libtest-venv \
   && /opt/libtest-venv/bin/pip install --no-cache-dir -r /tmp/requirements.txt \
+  # Python dependencies of library install scripts (e.g. Buildings EnergyPlus)
+  && /opt/libtest-venv/bin/pip install --no-cache-dir jinja2 \
   && rm /tmp/requirements.txt
 ENV PATH=/opt/libtest-venv/bin:$PATH
 


### PR DESCRIPTION
The Buildings library's install.py requires jinja2 to generate HTML tables for EnergyPlus Spawn actuator/output variables.