### PR TITLE
Fix BuildSysPro's external "C" include directory

### DIFF
--- a/configs/conf.json
+++ b/configs/conf.json
@@ -210,7 +210,9 @@
     "libraryVersionNameForTests":""
   },
   {
-    "library":"BuildSysPro"
+    "library":"BuildSysPro",
+    "_comment":"IncludeDirectory says modelica://BuildSysPro/Resources/C-Sources, which does not exist; the IBPSA C sources are in IBPSA/Resources/C-Sources (Resources/IBPSA/C-Sources in 3.5.0 and older). Some of them call str*/malloc/ModelicaError without including the header",
+    "extraCustomCommands":["setCFlags(getCFlags() + \" -include string.h -include stdlib.h -include ModelicaUtilities.h \\\"-I$libraryLocation/IBPSA/Resources/C-Sources\\\" \\\"-I$libraryLocation/Resources/IBPSA/C-Sources\\\"\")"]
   },
   {
     "library":"BusinessSimulation"

--- a/testmodel.py
+++ b/testmodel.py
@@ -508,10 +508,13 @@ except TimeoutError as e:
 
 execTimeTranslateModel=monotonic()-start
 simres = None
+buildFailed = False
 if useSimulate:
   simres = res or {}
-  # A failed translate/build is only reported in the messages of the record
-  res = not (simres.get("messages") or "").startswith("Failed to build model")
+  # A failed translate/build is only reported in the messages of the record; the
+  # translation clocks below say which of the two it was
+  buildFailed = (simres.get("messages") or "").startswith("Failed to build model")
+  res = True
 err        = omc.sendExpression("OpenModelica.Scripting.getErrorString()")
 total      = omc.sendExpression("OpenModelica.Scripting.Internal.Time.timerTock(OpenModelica.Scripting.Internal.Time.RT_CLOCK_SIMULATE_TOTAL)")-total_before
 buildmodel = omc.sendExpression("OpenModelica.Scripting.Internal.Time.timerTock(OpenModelica.Scripting.Internal.Time.RT_CLOCK_BUILD_MODEL)")
@@ -573,6 +576,10 @@ try:
     # a resimulate leaves it in the simulation time
     execstat["build"] = simres["timeCompile"] if useSimulate else 0.0
     execstat["phase"] = 5
+    if buildFailed:
+      with open(errFile, 'a+') as fp:
+        fp.write(simres.get("messages") or "")
+      writeResultAndExit(0, False, omc, omc_new)
   else:
     if isWin:
       res = checkOutputTimeout("\"%s\\share\\omc\\scripts\\Compile.bat\" %s gcc %s parallel dynamic 24 0" % (conf["omhome"], conf["fileName"], msysEnvironment), conf["ulimitOmc"], conf)


### PR DESCRIPTION
Its IncludeDirectory annotations name
modelica://BuildSysPro/Resources/C-Sources, which the library does not have — the IBPSA C sources are in IBPSA/Resources/C-Sources, and in a stale copy under Resources/IBPSA/C-Sources in 3.5.0 and older. omc therefore emitted no -I for them and every model reaching one failed to compile. Add both directories with setCFlags, plus the -include flags a few of those sources need: they call str*/malloc/ModelicaError without including the header, and only compile for the C target because the surrounding translation unit happens to have it.

With --nobuildmodel, translating and building share one simulate() call and only the record's messages says either failed. Tell them apart by the translation clocks, so a wasm-jit build failure — the JIT compile, or building the model's Include C sources — is reported as Compile rather than as SimCode or Simulate.

Assisted-by: Claude Opus 5