### PR TITLE
Workaround for older Buildings versions

### DIFF
--- a/configs/conf.json
+++ b/configs/conf.json
@@ -178,7 +178,8 @@
     "runOnceBeforeTesting":[["$resourceLocation/src/ThermalZones/install.py", "--binaries-for-os-only"]],
     "referenceFileExtension":"csv",
     "referenceFileNameDelimiter":"_",
-    "referenceFiles":"/mnt/ReferenceFiles/Buildings/csv/maint_11.x"
+    "referenceFiles":"/mnt/ReferenceFiles/Buildings/csv/maint_11.x",
+	"extraCustomCommands":["setCFlags(getCFlags() + \" -Wno-error=implicit-function-declaration\")"]
   },
   {
     "library":"Buildings",
@@ -190,7 +191,8 @@
     "runOnceBeforeTesting":[["$resourceLocation/src/ThermalZones/install.py", "--binaries-for-os-only"]],
     "referenceFileExtension":"csv",
     "referenceFileNameDelimiter":"_",
-    "referenceFiles":"/mnt/ReferenceFiles/Buildings/csv/maint_12.x"
+    "referenceFiles":"/mnt/ReferenceFiles/Buildings/csv/maint_12.x",
+	"extraCustomCommands":["setCFlags(getCFlags() + \" -Wno-error=implicit-function-declaration\")"]
   },
   {
     "library":"Buildings",


### PR DESCRIPTION
Newer clang complains about implicit function declarations