### PR TITLE
Record the node a container is running on, not the container id

### DIFF
--- a/resultsdb.py
+++ b/resultsdb.py
@@ -78,6 +78,30 @@ CREATE TABLE IF NOT EXISTS job_claim (
 # Jenkins sets LIBTEST_DB once for the whole pipeline rather than passing --db
 # to every script invocation.
 DEFAULT_DB = os.environ.get("LIBTEST_DB") or "sqlite3.db"
+
+
+def hostname():
+  """The machine the testing is running on, as something a human recognises.
+
+  socket.gethostname() is that machine, right up until the run is inside a
+  container, where it is the container id instead: job_claim holds rows saying
+  the wasm-jit libraries were tested by "e9725d308091", which identifies nothing
+  and is gone with the container. Jenkins does know the machine - it names its
+  agents - and propagates NODE_NAME into a container it starts, so prefer that
+  when there is a container to see through. LIBTEST_HOST overrides both, for
+  the same reason LIBTEST_DB exists.
+
+  Only consulted inside a container: outside one the kernel's answer is the
+  right one, and a NODE_NAME left over in the environment should not override
+  it.
+  """
+  explicit = os.environ.get("LIBTEST_HOST")
+  if explicit:
+    return explicit
+  # Docker leaves /.dockerenv behind, podman /run/.containerenv.
+  if os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv"):
+    return os.environ.get("NODE_NAME") or socket.gethostname()
+  return socket.gethostname()
 DB_HELP = ("Result database: a local sqlite3 file, or a postgresql://user@host/database URL for "
            "the shared one, taken from the LIBTEST_DB environment variable when not given. "
            "Several machines can write to the shared database at the same time; a library "
@@ -304,7 +328,7 @@ class _Postgres(_Db):
     self.lostConnection = (psycopg2.OperationalError, psycopg2.InterfaceError)
     self.pending = []
     self.conn = self._connect()
-    self.host = socket.gethostname()
+    self.host = hostname()
     self.claims = []
     self.heartbeatThread = None
     self.execute(JOB_CLAIM)

--- a/test.py
+++ b/test.py
@@ -12,7 +12,6 @@ import html, shutil, os, re, glob, time, argparse, datetime, math, platform
 from joblib import Parallel, delayed
 import simplejson as json
 import psutil, subprocess, threading, hashlib
-import socket
 from subprocess import call
 from monotonic import monotonic
 from omcommon import friendlyStr, multiple_replace
@@ -1011,7 +1010,7 @@ else:
   except:
     lsb_release = ""
 
-hostname = socket.gethostname()
+hostname = resultsdb.hostname()
 sysInfo = "%s: %s, %d GB RAM, %s%s" % (hostname, cpu_name(), int(math.ceil(psutil.virtual_memory().total / (1024.0**3))), ("Docker " + docker + " ") if docker else "", lsb_release)
 
 for (resultBranch, simulator) in resultBranches:


### PR DESCRIPTION
Follow-up to #320, which is merged.

#320 records `socket.gethostname()` as the machine that produced a library's results. That
is the machine right up until the run is inside a container, where it is the container id.
The database already shows the problem:

```
     host      | claims |            newest
---------------+--------+-------------------------------
 ryzen-9950x   |    724 | 2026-08-21 05:16:09+00
 ryzen-5950x-2 |    220 | 2026-08-21 11:38:04+00
 e9725d308091  |     96 | 2026-08-21 11:53:48+00     <- wasm-jit, in a container
 ryzen-5950x-1 |     28 | 2026-08-21 11:17:19+00
```

`e9725d308091` identifies no machine, and is gone with the container. Since #295 wants
every job running from a Docker image, that would become the answer everywhere and leave
the new `libversion.host` column as useless as having no column at all.

Jenkins knows the machine — it names its agents — and propagates `NODE_NAME` into a
container it starts, which is something `socket.gethostname()` inside that container
cannot see. So:

```python
def hostname():
  explicit = os.environ.get("LIBTEST_HOST")
  if explicit:
    return explicit
  # Docker leaves /.dockerenv behind, podman /run/.containerenv.
  if os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv"):
    return os.environ.get("NODE_NAME") or socket.gethostname()
  return socket.gethostname()
```

`NODE_NAME` is consulted **only** inside a container. Outside one the kernel's answer is
the right one and a `NODE_NAME` left over in the environment must not override it — which
is also what makes this a no-op for the machines running the testing today. `LIBTEST_HOST`
overrides both, for the same reason `LIBTEST_DB` exists, and is the escape hatch if some
job turns out not to have `NODE_NAME`.

It lives in `resultsdb` as one helper used by both callers, so the host in `job_claim` and
the host stored with the results cannot disagree about which machine this is. That also
fixes the wasm-jit claims above, not just the new columns.

Checked all four paths — plain host; `NODE_NAME` set but no container (unchanged, the real
hostname wins); `LIBTEST_HOST` set; and inside a container with and without `NODE_NAME`.
The container paths were exercised by faking the marker file rather than in a real
container, since Docker was not available where this was written; worth a real check on a
node before #295 leans on it.

Part of #301, and needed before #295's Docker task means anything for attribution.

---
generated by Claude Code
