### PR TITLE
Build omc with the cores the node has, not with 16 and 9

### DIFF
--- a/.CI/Jenkinsfile
+++ b/.CI/Jenkinsfile
@@ -657,6 +657,31 @@ def pullRequest() {
   return (params.pull_request ?: '').trim()
 }
 
+/**
+  * The cores of the node a build is running on, physical and logical, asked for
+  * the way the OpenModelica job asks (numPhysicalCPU in .CI/common.groovy
+  * there), so that a machine is built on as itself rather than as the machine
+  * the numbers were written for.
+  *
+  * Unlike that one the answer is not stashed in the environment: this pipeline
+  * is agent none and its stages run on several machines within one build, so a
+  * cached answer would be the first node's. An override set on the node itself
+  * is still honoured.
+  */
+def numPhysicalCPU() {
+  if (env.JENKINS_NUM_PHYSICAL_CPU) {
+    return env.JENKINS_NUM_PHYSICAL_CPU
+  }
+  return sh(script: 'lscpu -p | egrep -v "^#" | sort -u -t, -k 2,4 | wc -l', returnStdout: true).trim()
+}
+
+def numLogicalCPU() {
+  if (env.JENKINS_NUM_LOGICAL_CPU) {
+    return env.JENKINS_NUM_LOGICAL_CPU
+  }
+  return sh(script: 'nproc', returnStdout: true).trim()
+}
+
 def omsimulatorHash() {
   return 'master'
 }
@@ -930,6 +955,14 @@ def runRegressiontest(branch, name, extraFlags, omsHash, omcompiler, extrasimfla
   if (cmakeFlags && omcompiler) {
     error 'cmake builds need the OMCompiler directory of the OpenModelica repository (omcompiler=false)'
   }
+  // The build used to say -j9, the cores of the machine this file was written
+  // for in 2019, and -j16, the cores of the ryzen-5950x machines that replaced
+  // it - the commit that raised the others to 16 left the omc build at 9. Named
+  // buildJobs rather than jobs: that is this method's own parameter, how many
+  // models test.py tests at a time.
+  def buildJobs = numPhysicalCPU()
+  echo "Building omc with -j${buildJobs} on ${env.NODE_NAME}"
+
   def buildOMC
   if (cmakeFlags) {
     buildOMC = sccachePreamble() + """
@@ -939,7 +972,7 @@ def runRegressiontest(branch, name, extraFlags, omsHash, omcompiler, extrasimfla
       -DCMAKE_C_FLAGS=-march=native -DCMAKE_CXX_FLAGS=-march=native \
       -DOM_USE_CCACHE=OFF -DOM_ENABLE_GUI_CLIENTS=OFF -DOM_ENABLE_OMSIMULATOR=OFF \
       ${cmakeFlags} || exit 1
-    if ! time cmake --build ../build_cmake --parallel 16 --target install > log 2>&1; then
+    if ! time cmake --build ../build_cmake --parallel ${buildJobs} --target install > log 2>&1; then
       cat log
       exit 1
     fi
@@ -950,12 +983,12 @@ def runRegressiontest(branch, name, extraFlags, omsHash, omcompiler, extrasimfla
     buildOMC = """
     autoreconf --install
     ./configure --with-cppruntime --without-omc --disable-modelica3d CC=clang CXX=clang++ FC=gfortran CFLAGS='-O2 -march=native' --with-omlibrary=all --with-omniORB
-    time make -j16 clean
-    if ! time make -j9 omc > log 2>&1; then
+    time make -j${buildJobs} clean
+    if ! time make -j${buildJobs} omc > log 2>&1; then
       cat log
       exit 1
     fi
-    if ! time make -j16 runtimeCPPinstall > log 2>&1; then
+    if ! time make -j${buildJobs} runtimeCPPinstall > log 2>&1; then
       cat log
       if test "${name}" = "master"; then
         exit 1
@@ -1043,7 +1076,7 @@ def runRegressiontest(branch, name, extraFlags, omsHash, omcompiler, extrasimfla
   #   cat log
   #   exit 1
   # fi
-  if ! time make -j16 -C testsuite/ReferenceFiles > log 2>&1; then
+  if ! time make -j${numLogicalCPU()} -C testsuite/ReferenceFiles > log 2>&1; then
     cat log
     exit 1
   fi


### PR DESCRIPTION
The build commands carry the machines they were written for:

```groovy
time make -j16 clean
if ! time make -j9 omc > log 2>&1; then
if ! time make -j16 runtimeCPPinstall > log 2>&1; then
cmake --build ../build_cmake --parallel 16 --target install
make -j16 -C testsuite/ReferenceFiles
```

`-j9` is the machine this file was written for in 2019 (`836da12`, "Add a
Jenkinsfile for ripper", where everything was `-j9`). `-j16` arrived in 2021 with
`26bdeae`, **"Build OMC with a few more threads"**, which raised every `-j9` in
the file to 16 - except the one it was named after:

```
-    time make -j9 clean
+    time make -j16 clean
-    if ! time make -j9 runtimeCPPinstall > log 2>&1; then
+    if ! time make -j16 runtimeCPPinstall > log 2>&1; then
-  if ! time make -j9 -C testsuite/ReferenceFiles > log 2>&1; then
+  if ! time make -j16 -C testsuite/ReferenceFiles > log 2>&1; then
```

`make -j9 omc` is untouched by that commit and has been building omc on nine of
the sixteen cores of a `ryzen-5950x` ever since. It is not a memory limit anyone
chose; it is the number the file was born with.

## What changes

The node is asked, the way the OpenModelica job asks - `numPhysicalCPU` in
`.CI/common.groovy` there, same `lscpu` incantation, same
`JENKINS_NUM_PHYSICAL_CPU` override:

- **physical cores** for the compiles (`clean`, `omc`, `runtimeCPPinstall`, the
  cmake build) - which is what `-j16` already was on these machines, so the only
  change there is the omc build going from 9 to 16. That is also what the
  OpenModelica job builds omc with on the same class of machine;
- **logical cores** for `testsuite/ReferenceFiles`, which is the split that job
  uses for exactly that target.

Unlike `common.groovy` the answer is **not** stashed in the environment: this
pipeline is `agent none` and its stages run on `ryzen-5950x-1`,
`ryzen-5950x-2-1`, `ryzen-9950x` and `linux` within one build, so a cached answer
would be whichever node asked first. An override set on the node itself is still
honoured. The count is asked for once per run and echoed with the node name, so a
build says what it built with:

```
Building omc with -j16 on ryzen-5950x-1
```

## One thing worth a second look

`runRegressiontest` already has a parameter called `jobs` - how many models
`test.py` tests at a time, which `heavy_tests` sets to `1` - so the new variable
is `buildJobs`. Calling it `jobs` would have shadowed the parameter and let
`heavy_tests` loose with sixteen models at once.

---
Generated by Claude Code.
