### PR TITLE
Publish a pull request under pr/, not beside the branches (#307)

### DIFF
--- a/.CI/Jenkinsfile
+++ b/.CI/Jenkinsfile
@@ -150,9 +150,13 @@ pipeline {
           fi
           """
           // One build of omc per pull request is kept, as for a branch, and they
-          // accumulate: a pull request is tested once and never again.
-          sh 'find "$HOME/saved_omc" -maxdepth 1 -name "pr-*" -type d -mtime +14 -exec rm -rf {} ";" || true'
-          runRegressiontest("pr-${pullRequest()}", "pr-${pullRequest()}", '', '', false, '', '', false, false, 0, params.pull_request_config ?: 'configs/conf.json')
+          // accumulate: a pull request is tested once and never again. The
+          // second line is the layout of the runs before they moved under pr/.
+          sh '''
+          find "$HOME/saved_omc/pr" -mindepth 1 -maxdepth 1 -type d -mtime +14 -exec rm -rf {} ";" 2> /dev/null || true
+          find "$HOME/saved_omc" -mindepth 1 -maxdepth 1 -name "pr-*" -type d -mtime +14 -exec rm -rf {} ";" || true
+          '''
+          runRegressiontest("pr/${pullRequest()}", "pr/${pullRequest()}", '', '', false, '', '', false, false, 0, params.pull_request_config ?: 'configs/conf.json')
         }
       }
 
@@ -910,7 +914,7 @@ def runRegressiontest(branch, name, extraFlags, omsHash, omcompiler, extrasimfla
   // head one, since the question is what happens once it is merged, and it is
   // checked out detached so that nothing is left behind for the next run of the
   // same workspace to trip over.
-  def pullRequest = branch.startsWith('pr-') && branch.substring(3).isInteger() ? branch.substring(3) : ''
+  def pullRequest = branch.startsWith('pr/') && branch.substring(3).isInteger() ? branch.substring(3) : ''
   def checkoutRef = pullRequest ? """
     REFS=`git ls-remote https://github.com/OpenModelica/OpenModelica.git "refs/pull/${pullRequest}/head" "refs/pull/${pullRequest}/merge"` || exit 1
     case "\$REFS" in

--- a/README.md
+++ b/README.md
@@ -268,14 +268,19 @@ None of the branch jobs run unless their own parameter is ticked as well.
 
 By hand it is two steps. The compiler is built from the merge ref - the pull
 request as it would land, not the branch on its own - and the run fills a
-`pr-<N>` table like any other branch:
+`pr/<N>` table like any other branch:
 
 ```bash
 git fetch --force https://github.com/OpenModelica/OpenModelica.git refs/pull/<N>/merge
 git checkout -f --detach FETCH_HEAD
 # build omc, then
-./test.py --branch=pr-<N> configs/conf.json
+./test.py --branch=pr/<N> configs/conf.json
 ```
+
+`pr/<N>` rather than `pr-<N>`: the results of a pull request are stored and
+published under `pr/`, so that `branches/` holds branches and the pull requests
+sit together in one directory of it. It is the one job name that keeps the
+directory part of its name - `maintenance/v1.27` is tested as `v1.27`.
 
 and the report compares that run against the newest run of `master`:
 
@@ -283,7 +288,7 @@ and the report compares that run against the newest run of `master`:
 ./pr-report.py <N>                 # --baseline=master by default
 ```
 
-It writes `history/pr-<N>/<baseline run>..<pull request run>.html`, the same
+It writes `history/pr/<N>/<baseline run>..<pull request run>.html`, the same
 kind of page as the nightly regression reports, next to `00_comment.md`, a
 summary to comment on the pull request with. Both are published with the other
 reports.
@@ -306,7 +311,7 @@ is based on, so a difference can come from anything merged since it was
 branched - a reason to rebase before believing a surprising result.
 
 A full run takes days, so testing every pull request this way is not the idea;
-point `--branch=pr-<N>` at a smaller configuration file when the question is
+point `--branch=pr/<N>` at a smaller configuration file when the question is
 narrower.
 
 The tables accumulate, about 19500 rows each. `drop-pr-tables.py` drops the ones

--- a/all-plots.py
+++ b/all-plots.py
@@ -21,7 +21,7 @@ parser.add_argument('--historypath', default="history")
 resultsdb.addArgument(parser)
 args = parser.parse_args()
 
-branches = [branch.split("/")[-1] for branch in args.branches]
+branches = [shared.resultTable(branch) for branch in args.branches]
 fnameprefix = args.historypath
 
 libs = {}

--- a/all-reports.py
+++ b/all-reports.py
@@ -23,7 +23,7 @@ args = parser.parse_args()
 os.environ['TZ'] = 'Europe/Stockholm'
 time.tzset()
 
-branches = [branch.split("/")[-1] for branch in args.branches]
+branches = [shared.resultTable(branch) for branch in args.branches]
 baseurl = args.baseurl
 historyurl  = args.historyurl
 githuburl = args.githuburl

--- a/drop-pr-tables.py
+++ b/drop-pr-tables.py
@@ -23,7 +23,9 @@ parser.add_argument('--yes', action='store_true', help='actually drop them')
 resultsdb.addArgument(parser)
 args = parser.parse_args()
 
-prTableRe = re.compile(r"^pr-([0-9]+)$")
+# pr/<N> is what a run fills; pr-<N> is what the runs before that filled, and
+# they are dropped by the same rule.
+prTableRe = re.compile(r"^pr[-/]([0-9]+)$")
 
 db = resultsdb.connect(args.db)
 cursor = db.cursor()

--- a/pr-report.py
+++ b/pr-report.py
@@ -16,7 +16,7 @@ import shared, resultsdb
 from omcommon import friendlyStr, multiple_replace
 
 parser = argparse.ArgumentParser(description='OpenModelica library testing pull request report')
-parser.add_argument('pullrequest', help='the pull request number, or its branch name pr-<N>')
+parser.add_argument('pullrequest', help='the pull request number, or its branch name pr/<N>')
 parser.add_argument('--baseline', default="master", help='the branch the pull request is compared against')
 parser.add_argument('--date', type=int, default=0, help='the pull request run to report on (default: its newest)')
 parser.add_argument('--baselinedate', type=int, default=0, help='the baseline run to compare against (default: its newest)')
@@ -40,12 +40,14 @@ timeAbs = 10     # Ignore performance regressions for times <10s...
 
 PHASES = [(1,"frontend"),(2,"backend"),(3,"simcode"),(4,"templates"),(5,"compile"),(6,"simulate")]
 
-m = re.match(r"^(?:pr-)?([0-9]+)$", args.pullrequest.strip())
+m = re.match(r"^(?:pr[-/])?([0-9]+)$", args.pullrequest.strip())
 if not m:
-  raise SystemExit("Expected a pull request number or a pr-<N> branch name, got '%s'" % args.pullrequest)
+  raise SystemExit("Expected a pull request number or a pr/<N> branch name, got '%s'" % args.pullrequest)
 pr = m.group(1)
-branch = "pr-%s" % pr
-baseline = args.baseline.split("/")[-1]
+# The results of a pull request live under pr/, not beside the branches; see
+# shared.resultTable.
+branch = "pr/%s" % pr
+baseline = shared.resultTable(args.baseline)
 prurl = "%s/pull/%s" % (args.githuburl, pr)
 repo = args.githuburl.split("github.com/")[-1].strip("/")
 

--- a/report.py
+++ b/report.py
@@ -15,7 +15,7 @@ configs = args.configs
 if configs == []:
   raise Exception("Error: Expected at least one configuration file to start the library test")
 
-branches = [br.split("/")[-1] for br in args.branches.split(" ")]
+branches = [shared.resultTable(br) for br in args.branches.split(" ")]
 
 dates = {}
 dates_str = {}

--- a/shared.py
+++ b/shared.py
@@ -3,6 +3,16 @@
 import re, os, string, subprocess
 import simplejson as json
 
+# A job is named after the branch it tests, and takes the last part of the name:
+# maintenance/v1.27 is stored and published as v1.27. A pull request is the
+# exception - pr/16370 keeps the directory it is in, so that the branches
+# directory holds branches and the pull requests sit together under one of them.
+prBranchRe = re.compile(r"^pr/[0-9]+$")
+
+def resultTable(branch):
+  """The results of a job named after this branch: its table and its directory."""
+  return branch if prBranchRe.match(branch) else branch.split("/")[-1]
+
 simCodeTargetRe = re.compile('--simCodeTarget=([^"\'\\s,;)]+)')
 
 def simCodeTargetFromCommands(target, commands):

--- a/single-model.py
+++ b/single-model.py
@@ -12,7 +12,7 @@ resultsdb.addArgument(parser)
 
 args = parser.parse_args()
 
-branch = args.branch.split("/")[-1]
+branch = shared.resultTable(args.branch)
 models = args.models
 
 dates = {}


### PR DESCRIPTION
A pull request run was named `pr-<N>`, so its results landed in
`branches/pr-16370` next to `master`, `v1.27`, `cpp` and the 65 other
directories there, and its reports in `branches/history/pr-16370`. One directory
per pull request tested would bury the branches.

The name is **`pr/<N>`**, which is a directory of its own:

```
branches/pr/16370/                          the per-library results
branches/history/pr/16370/                  the report and the summary
```

## The one name that keeps its directory

Every other job is named after a git branch and takes only the last part of the
name - `maintenance/v1.27` is tested, stored and published as `v1.27`. That rule
was a `split("/")[-1]` in each of `report.py`, `all-reports.py`, `all-plots.py`,
`single-model.py` and `pr-report.py`; it is now one place:

```python
prBranchRe = re.compile(r"^pr/[0-9]+$")

def resultTable(branch):
  """The results of a job named after this branch: its table and its directory."""
  return branch if prBranchRe.match(branch) else branch.split("/")[-1]
```

`report.py --branches='master pr/<N>'` works as a side effect, which it would not
have before: the name would have been cut down to the number.

`drop-pr-tables.py` matches `pr[-/]<N>`, so the tables of the runs made before
this are dropped by the same rule.

## The run that is already there

PR #16370 was tested before this - `pr-16370`, 19661 models - and stays exactly
where it is. Nothing here moves it and nothing needs to: this is for the runs
from here on. `drop-pr-tables.py` matches `pr[-/]<N>`, so it goes the same way as
any other once the pull request is merged or closed.

## Tested

Against a sqlite database whose pull request table is `pr/1234`:

| | |
| --- | --- |
| `./pr-report.py 1234` | writes `history/pr/1234/`, and the model links point at `branches/pr/1234/...` while the baseline ones point at `branches/master/...` |
| `./report.py --branches='master pr/1234'` | the pull request column links to `pr/1234/...` |
| `./drop-pr-tables.py` | lists `pr/1234` and `pr-16357` together, drops the merged one |
| the sanity check the CI runs | `test.py --branch=stable configs/sanityCheck.json`, then `report.py`, then the `grep` from `.github/workflows/test.yml`: passes |

---
Generated by Claude Code.
