### PR TITLE
Compile master and PRs with CMake

### DIFF
--- a/.CI/Jenkinsfile
+++ b/.CI/Jenkinsfile
@@ -785,6 +785,18 @@ def sccachePreamble() {
 }
 
 /**
+  * Whether omc is built with cmake for `branch`, rather than with Autoconf and Makefiles.
+  *
+  * The Autoconf+Make build is being removed from OpenModelica (OpenModelica/OpenModelica#14387),
+  * so master - and the pull requests that would be merged into it - is built with cmake. The
+  * maintenance branches are still released from the Autoconf build and keep it until they are
+  * dropped.
+  */
+def buildsWithCMake(branch) {
+  return !branch.startsWith('maintenance/')
+}
+
+/**
   * Launches the test.py script with the given options.
   *
   * @param branch:              OpenModelica branch to test. Will checkout the branch and build omc from it.
@@ -802,8 +814,9 @@ def sccachePreamble() {
   *                             physical cpus on the machine'.
   * @param libs_config_file:    The config file to be used for testing.
   *                             This file specifies which libraries to test and what options to use for them.
-  * @param cmakeFlags:          Target-specific cmake flags, e.g. `-DOM_OMC_ENABLE_RUST=ON`. If non-empty, omc is
-  *                             built with cmake instead of autotools; the shared release flags are added here.
+  * @param cmakeFlags:          Target-specific cmake flags, e.g. `-DOM_OMC_ENABLE_RUST=ON`, added to the
+  *                             shared release flags. Only for the branches built with cmake, see
+  *                             buildsWithCMake().
   * @param dockerfile:          Directory with a Dockerfile, relative to the testing repository. Defaults to
   *                             `.CI/testing`, the image every job runs in: the omc build, the OMSimulator
   *                             build and test.py happen inside it, and only the steps using the node's own
@@ -985,10 +998,18 @@ def runRegressiontest(branch, name, extraFlags, omsHash, omcompiler, extrasimfla
 
   OMCPATH = "${omcompiler ? '../' : './'}OMCompiler"
 
+  def useCMake = buildsWithCMake(branch)
   // The build runs in OMCompiler, one level below the cmake source tree.
-  if (cmakeFlags && omcompiler) {
+  if (useCMake && omcompiler) {
     error 'cmake builds need the OMCompiler directory of the OpenModelica repository (omcompiler=false)'
   }
+  if (cmakeFlags && !useCMake) {
+    error "${branch} is built with Autoconf and has no use for the cmake flags ${cmakeFlags}"
+  }
+  // Only the target sharing the compile cache of the OpenModelica job has something to look up in
+  // it; starting a server for the other cmake builds would just cost them the credentials and the
+  // startup.
+  def useSccache = cmakeFlags.contains('sccache')
   // The build used to say -j9, the cores of the machine this file was written
   // for in 2019, and -j16, the cores of the ryzen-5950x machines that replaced
   // it - the commit that raised the others to 16 left the omc build at 9. Named
@@ -1000,22 +1021,28 @@ def runRegressiontest(branch, name, extraFlags, omsHash, omcompiler, extrasimfla
   // Not -march=native: the nodes differ in microarchitecture and the shared sccache
   // cannot tell two `-march=native` command lines apart (AVX-512 object -> SIGILL).
   def buildOMC
-  if (cmakeFlags) {
-    buildOMC = sccachePreamble() + """
+  if (useCMake) {
+    buildOMC = (useSccache ? sccachePreamble() : '') + """
     cmake -S .. -B ../build_cmake -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX="`pwd`/build" \
-      -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_Fortran_COMPILER=gfortran \
-      -DCMAKE_C_FLAGS=-march=x86-64-v3 -DCMAKE_CXX_FLAGS=-march=x86-64-v3 \
-      -DOM_USE_CCACHE=OFF -DOM_ENABLE_GUI_CLIENTS=OFF -DOM_ENABLE_OMSIMULATOR=OFF \
+      -DCMAKE_C_COMPILER=clang \
+      -DCMAKE_CXX_COMPILER=clang++ \
+      -DCMAKE_Fortran_COMPILER=gfortran \
+      -DCMAKE_C_FLAGS=-march=x86-64-v3 \
+      -DCMAKE_CXX_FLAGS=-march=x86-64-v3 \
+      -DOM_USE_CCACHE=OFF \
+      -DOM_ENABLE_GUI_CLIENTS=OFF \
+      -DOM_ENABLE_OMSIMULATOR=OFF \
+      -DOM_OMC_ENABLE_CPP_RUNTIME=ON \
       ${cmakeFlags} || exit 1
     if ! time cmake --build ../build_cmake --parallel ${buildJobs} --target install > log 2>&1; then
       cat log
       exit 1
     fi
     build/bin/omc --version || exit 1
-    sccache --show-stats || true
-    """
+    """ + (useSccache ? 'sccache --show-stats || true\n' : '')
   } else {
+    // The maintenance branches only, see buildsWithCMake().
     buildOMC = """
     autoreconf --install
     ./configure --with-cppruntime --without-omc --disable-modelica3d CC=clang CXX=clang++ FC=gfortran CFLAGS='-O2 -march=x86-64-v3' --with-omlibrary=all --with-omniORB
@@ -1024,13 +1051,11 @@ def runRegressiontest(branch, name, extraFlags, omsHash, omcompiler, extrasimfla
       cat log
       exit 1
     fi
+    # master used to fail the build here and the other targets to carry on without a C++ runtime.
+    # Only the maintenance branches are left, so a failure is no longer fatal for anyone.
     if ! time make -j${buildJobs} runtimeCPPinstall > log 2>&1; then
       cat log
-      if test "${name}" = "master"; then
-        exit 1
-      else
-        echo "Ignoring failed C++ runtime"
-      fi
+      echo "Ignoring failed C++ runtime"
     fi
     """
   }
@@ -1078,6 +1103,9 @@ def runRegressiontest(branch, name, extraFlags, omsHash, omcompiler, extrasimfla
   export OPENMODELICAHOME="`pwd`/build"
 
   git rev-parse --verify HEAD > .newhash
+  # Part of the stamp rather than the commit alone: a build/ cached from the other build system is
+  # not what this job would produce for the same commit.
+  echo "${useCMake ? 'cmake' : 'autotools'}" >> .newhash
   echo New Hash:
   cat .newhash
   echo Old Hash:
@@ -1113,7 +1141,7 @@ def runRegressiontest(branch, name, extraFlags, omsHash, omcompiler, extrasimfla
   fi
   """
 
-  if (cmakeFlags) {
+  if (useSccache) {
     withSccache { runSh(checkoutAndBuild) }
   } else {
     runSh(checkoutAndBuild)

--- a/.CI/testing/Dockerfile
+++ b/.CI/testing/Dockerfile
@@ -13,9 +13,9 @@ FROM docker.openmodelica.org/build-deps:ubuntu-26.04-rust
 # rsync/ssh publish the results; time and killall are used around test.py.
 # libcomedi-dev libx11-dev is used by Modelica_DeviceDrivers
 # Python 3.8 and 3.12 are used by Buildings
-# autoconf/automake/libtool and omniORB build the targets that do not ask for a cmake omc: those
-# still go through `autoreconf && ./configure --with-omniORB`. The base image carries what the
-# cmake build needs, which is not quite the same set.
+# autoconf/automake/libtool and omniORB build the maintenance branches: master builds with cmake,
+# while v1.26 and v1.27 still go through `autoreconf && ./configure --with-omniORB`. The base image
+# carries what the cmake build needs, which is not quite the same set.
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
   && apt-get install -qy software-properties-common \


### PR DESCRIPTION
## Issue

Closes https://github.com/OpenModelica/OpenModelicaLibraryTesting/issues/337.

## Changes

* `master` branch and PRs are now build with CMake
* Older `maintenance/*` branches will still use Autoconf+Makeflie. That has to change once v1.28 gets released and moves to `maintenance/v1.28`.