### PR TITLE
Rebuild cached omc/OMSimulator that do not run in the image

### DIFF
--- a/.CI/Jenkinsfile
+++ b/.CI/Jenkinsfile
@@ -910,7 +910,10 @@ def runRegressiontest(branch, name, extraFlags, omsHash, omcompiler, extrasimfla
     echo Old Hash:
     cat ~/saved_omc/OMSimulator/.githash || true
 
-    if ! (cmp ~/saved_omc/OMSimulator/.githash .newhash); then
+    # The second test rebuilds a cached build that does not run here: one made on
+    # the node before the job moved into a container, or against an older image,
+    # matches by hash but misses the libraries it was linked against.
+    if ! cmp ~/saved_omc/OMSimulator/.githash .newhash || ! ~/saved_omc/OMSimulator/install/bin/OMSimulator --version; then
 
       git submodule sync --recursive || exit 1
       git clean -ffdx || exit 1
@@ -1071,8 +1074,27 @@ def runRegressiontest(branch, name, extraFlags, omsHash, omcompiler, extrasimfla
   cat .newhash
   echo Old Hash:
   cat ~/saved_omc/${name}/.githash || true
-  # TODO: Create a docker image for these things instead?
-  if ! (cmp ~/saved_omc/${name}/.githash .newhash || test -f ~/saved_omc/${name}/.nogit); then
+  REBUILD=""
+  if cmp ~/saved_omc/${name}/.githash .newhash || test -f ~/saved_omc/${name}/.nogit; then
+    rsync -a --delete ~/saved_omc/${name}/ build/ || exit 1
+    echo "Restoring cached OMC version: ${name}, `cat ~/saved_omc/${name}/.githash`"
+    # The hash says the sources match, not that the binary runs here: a cache
+    # filled on the node before the jobs moved into a container, or before the
+    # image changed, holds an omc linked against libraries that are missing now.
+    # Without this check the run dies much later, when test.py asks the restored
+    # binary for its version and gets exit code 127.
+    if ! build/bin/omc --version; then
+      if test -f ~/saved_omc/${name}/.nogit; then
+        echo "The cached omc of ${name} does not run in this environment, and .nogit forbids rebuilding it."
+        exit 1
+      fi
+      echo "The cached omc of ${name} does not run in this environment; rebuilding it."
+      REBUILD=1
+    fi
+  else
+    REBUILD=1
+  fi
+  if test -n "\$REBUILD"; then
     ${buildOMC}
     rm -rf ~/saved_omc/${name}/
     mkdir -p ~/saved_omc/${name}/
@@ -1080,9 +1102,6 @@ def runRegressiontest(branch, name, extraFlags, omsHash, omcompiler, extrasimfla
     echo \$CMD
     \$CMD || exit 1
     cp .newhash ~/saved_omc/${name}/.githash
-  else
-    rsync -a --delete ~/saved_omc/${name}/ build/ || exit 1
-    echo "Restoring cached OMC version: ${name}, `cat ~/saved_omc/${name}/.githash`"
   fi
   """
 
@@ -1155,7 +1174,9 @@ def runRegressiontest(branch, name, extraFlags, omsHash, omcompiler, extrasimfla
     stdbuf -oL -eL time ./test.py --ompython_omhome=/usr ${FMI_TESTING_FLAG} --extraflags='${extraFlags}' --extrasimflags='${extrasimflags}' ${testFlags} --branch="${name}" --output="libraries.openmodelica.org:/var/www/libraries.openmodelica.org/branches/${name}/" --libraries='${libraryPath}/.openmodelica/libraries/'  --jobs=${jobs} ${libs_config_file} ${params.OLDLIBS ? "configs/conf-old.json configs/conf-nonstandard.json" : ""} || (killall omc ; false) || exit 1
     """)
     sh 'date'
-    sh "cd OpenModelicaLibraryTesting/ && ./clean-empty-omcversion-dates.py"
+    // In the image: the script talks to the results database through psycopg2,
+    // which is in the image's python environment and not on the node.
+    runSh("cd OpenModelicaLibraryTesting/ && ./clean-empty-omcversion-dates.py")
   }
 
 }


### PR DESCRIPTION
## Issue

https://github.com/OpenModelica/OpenModelicaLibraryTesting/pull/335 broke the library testing.

Jenkins reports errors in the master stage like: 

```
cd OpenModelicaLibraryTesting/ && ./clean-empty-omcversion-dates.py— Shell Script<1s
+ cd OpenModelicaLibraryTesting/
+ ./clean-empty-omcversion-dates.py
PostgreSQL support needs psycopg2: pip install psycopg2-binary
script returned exit code 1
```

The maintenance branches reports errors like:

```
Shell Script<1s
+ export OPENMODELICAHOME=/var/lib/jenkins/ws/OpenModelicaLibraryTestingWork/OpenModelica/./OMCompiler/build
+ export MSLREFERENCE=/var/lib/jenkins/ws/OpenModelicaLibraryTestingWork/Reference-modelica.org/ReferenceResults
+ export REFERENCEFILES=/var/lib/jenkins/ws/OpenModelicaLibraryTestingWork/OpenModelica/testsuite/ReferenceFiles
+ export GITREPOS=/var/lib/jenkins/ws/OpenModelicaLibraryTestingWork/OpenModelica/libraries/git
+ export PNLIBREFS=/mnt/ReferenceFiles/PNlib/ReferenceFiles
+ export THERMOFLUIDSTREAMREFS=/mnt/ReferenceFiles/ThermofluidStream-main-regression/ReferenceData
+ export THERMOFLUIDSTREAMREFSOM=/mnt/ReferenceFiles/ThermofluidStream-OM-regression/ReferenceData
+ export PREVIOUSHOME=/home/hudson
+ export HOME=/home/hudson/saved_omc/libraries
+ ln -s -t /home/hudson/saved_omc/libraries /home/hudson/.local .local
ln: Already exists
ln: will not overwrite just-created '/home/hudson/saved_omc/libraries/.local' with '.local'
+ true
+ cat /sys/fs/cgroup/memory.max
57224986624
+ trap cat /sys/fs/cgroup/memory.peak /sys/fs/cgroup/memory.events || true EXIT
+ cd OpenModelicaLibraryTesting
+ stdbuf -oL -eL time ./test.py --ompython_omhome=/usr --extraflags= --extrasimflags= --branch=v1.26 --output=libraries.openmodelica.org:/var/www/libraries.openmodelica.org/branches/v1.26/ --libraries=/home/hudson/saved_omc/libraries/.openmodelica/libraries/ --jobs=0 configs/conf.json
branch: v1.26, n_jobs: 16
Removing temporary files, etc to the best ability of the script
Start OMC version
Traceback (most recent call last):
  File "/var/lib/jenkins/ws/OpenModelicaLibraryTestingWork/OpenModelicaLibraryTesting/./test.py", line 322, in <module>
    omc_version = check_output_log(omc_cmd + ["--version"], stderr=subprocess.STDOUT).decode("ascii").strip()
                  ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/jenkins/ws/OpenModelicaLibraryTestingWork/OpenModelicaLibraryTesting/./test.py", line 170, in check_output_log
    return subprocess.check_output(*popenargs, **kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/subprocess.py", line 473, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
               **kwargs).stdout
               ^^^^^^^^^
  File "/usr/lib/python3.14/subprocess.py", line 578, in run
    raise CalledProcessError(retcode, process.args,
                             output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/var/lib/jenkins/ws/OpenModelicaLibraryTestingWork/OpenModelica/OMCompiler/build/bin/omc', '--version']' returned non-zero exit status 127.
Command exited with non-zero status 1
5.17user 0.09system 0:00.46elapsed 1140%CPU (0avgtext+0avgdata 57196maxresident)k
40248inputs+120outputs (83major+18585minor)pagefaults 0swaps
+ killall omc
omc: no process found
+ false
+ exit 1
+ cat /sys/fs/cgroup/memory.peak /sys/fs/cgroup/memory.events
96624640
low 0
high 0
max 0
oom 0
oom_kill 0
oom_group_kill 0
script returned exit code 1
```

## Changes

Since the jobs moved into a container, a cache keyed on the git hash alone restores binaries built on the node: the maintenance branches have not moved, so v1.26 and v1.27 got a node-built omc that cannot load inside the image and died as exit code 127 out of test.py. Check that the restored build runs and rebuild it if it does not, for omc and for OMSimulator.

Also run clean-empty-omcversion-dates.py in the image: it needs psycopg2, which is in the image's python environment and not on the node.