### PR TITLE
wasm-jit: run --daeMode models in DAE mode with the me runner

### DIFF
--- a/configs/wasm-jit-runners.json
+++ b/configs/wasm-jit-runners.json
@@ -9,6 +9,8 @@
     "model is translated and compiled once however many of them run.",
     "",
     "simflags       what is appended to the model's simulation flags; -s fmi3:… picks the interface.",
+    "daeModeSimflags  the same for a model that asks for --daeMode, whose Model Exchange interface is",
+    "               a DAE one (fmi-ls-dae); a runner without it runs such a model with simflags.",
     "description    what the runner is, for the reports.",
     "branchSuffix   appended to --branch to get the table of this runner; the default is -<name>, so",
     "               the artifact's own simulation runtime is the one that needs to say anything here."
@@ -20,7 +22,8 @@
   },
   "me": {
     "simflags": "-s fmi3:me:daskr",
-    "description": "FMI 3.0 Model Exchange, integrated by omc with DASKR"
+    "daeModeSimflags": "-s fmi3:me -daeMode",
+    "description": "FMI 3.0 Model Exchange, integrated by omc with DASKR (IDA over the fmi-ls-dae residuals for a --daeMode model)"
   },
   "cs": {
     "simflags": "-s fmi3:cs",

--- a/testmodel.py
+++ b/testmodel.py
@@ -474,9 +474,8 @@ def modelCommandLineOptions():
     opts += commandLineOptionsRe.findall(text)
   return " ".join(opts)
 
-# A --daeMode model has no explicit ODE, so it has no FMI Model Exchange
-# interface: the export drops ME and the artifact serves Co-Simulation (and its
-# own simulation) only. Drop the runners that ask for what is not there.
+# A --daeMode model's Model Exchange interface is a DAE one (fmi-ls-dae): the
+# runners that care say how to drive it.
 daeMode = useArtifact and "--daeMode" in (modelCommandLineOptions() + " " + " ".join(str(c) for c in conf["customCommands"]))
 
 def simulateCmd(resimulate):
@@ -634,12 +633,7 @@ wasmjitrunners = shared.parseWasmJitRunners(conf.get("wasmjitrunners")) if useAr
 # described in configs/solvers.json.
 solverRunners = shared.parseSolvers(conf.get("solvers")) if not conf.get("fmi") and not isWasmJit else []
 if daeMode:
-  meRunners = [name for (name, flags) in wasmjitrunners if ":me:" in flags or flags.endswith(":me")]
-  if meRunners:
-    with open(errFile, 'a+') as fp:
-      fp.write("The model asks for --daeMode, which has no FMI Model Exchange interface: "
-               "not running %s\n" % ", ".join(meRunners))
-    wasmjitrunners = [r for r in wasmjitrunners if r[0] not in meRunners]
+  wasmjitrunners = [(name, shared.wasmJitRunner(name).get("daeModeSimflags") or flags) for (name, flags) in wasmjitrunners]
 # One build, several runs: an FMU simulated by several tools, a wasm artifact run
 # several ways and a model run by several solvers fan out the same way.
 runners = fmisimulators or wasmjitrunners or solverRunners


### PR DESCRIPTION
The `me` runner was dropped for a `--daeMode` model, because omc's wasm FMU export had no Model Exchange interface for one. It now has: the FMU follows fmi-ls-dae, and `simulate(..., simflags="-s fmi3:me -daeMode")` integrates its residuals with IDA. A runner can name the flags it takes for such a model (`daeModeSimflags`); the `me` runner does, the others run as before.

Assisted-by: Claude Fable 5