### PR TITLE
Record each model's peak memory in the database

### DIFF
--- a/resultsdb.py
+++ b/resultsdb.py
@@ -38,6 +38,7 @@ BRANCH_COLUMNS = [
     ("frontend", "real"), ("backend", "real"), ("simcode", "real"), ("templates", "real"),
     ("compile", "real"), ("simulate", "real"), ("verify", "real"),
     ("verifyfail", "int"), ("verifytotal", "int"), ("finalphase", "int"), ("parsing", "real"),
+    ("maxrss", "bigint"),
 ]
 SQLITE_TYPES = {"bigint": "integer", "int": "integer", "real": "real", "text": "text"}
 POSTGRES_TYPES = {"bigint": "bigint", "int": "integer", "real": "double precision", "text": "text"}
@@ -310,8 +311,10 @@ class _Sqlite(_Db):
       self.addLibversionHost(cursor)
     elif user_version == 3:
       self.addLibversionHost(cursor)
-    elif user_version != 4:
+    elif user_version not in (4, 5):
       raise SystemExit("Unknown schema user_version=%d" % user_version)
+    if 0 < user_version < 5:
+      self.addMaxrss(cursor)
 
     cols = ", ".join("%s %s NOT NULL" % (c, SQLITE_TYPES[t]) for c, t in BRANCH_COLUMNS)
     cursor.execute("CREATE TABLE if not exists %s (%s)" % (self.quote(branch), cols))
@@ -319,7 +322,14 @@ class _Sqlite(_Db):
     cursor.execute("DROP INDEX IF EXISTS [idx_%s_date]" % branch)
     cursor.execute("DROP INDEX IF EXISTS idx_omcversion_date")
     cursor.execute("DROP INDEX IF EXISTS idx_libversion_date")
-    self.setUserVersion(4)
+    self.setUserVersion(5)
+
+  def addMaxrss(self, cursor):
+    """Add maxrss to every result table that predates it; older rows read 0."""
+    for tbl in self.tables():
+      have = self.columns(tbl)
+      if "finalphase" in have and "maxrss" not in have:
+        cursor.execute("ALTER TABLE %s ADD COLUMN maxrss integer NOT NULL DEFAULT(0)" % self.quote(tbl))
 
   def addLibversionHost(self, cursor):
     """Add the host columns to an existing [libversion].
@@ -508,6 +518,7 @@ class _Postgres(_Db):
     cols = ", ".join("%s %s%s" % (c, POSTGRES_TYPES[t], " NOT NULL" if c in BRANCH_KEY else "")
                      for c, t in BRANCH_COLUMNS)
     cursor.execute("CREATE TABLE IF NOT EXISTS %s (%s)" % (self.quote(branch), cols))
+    cursor.execute("ALTER TABLE %s ADD COLUMN IF NOT EXISTS maxrss bigint" % self.quote(branch))
     for tbl in ["omcversion", "libversion", branch]:
       key = KEYS.get(tbl, BRANCH_KEY)
       cursor.execute("CREATE UNIQUE INDEX IF NOT EXISTS %s ON %s (%s)"

--- a/sqlite2postgres.py
+++ b/sqlite2postgres.py
@@ -64,6 +64,7 @@ BRANCH_COLUMNS = [
     ("verifytotal", "integer"),
     ("finalphase", "integer"),
     ("parsing", "double precision"),
+    ("maxrss", "bigint"),
 ]
 
 LOOKUP_COLUMNS = {
@@ -208,6 +209,9 @@ def create_table(pg, tbl, columns):
   cols = ",\n  ".join("%s %s%s" % (ident(c), t, " NOT NULL" if c in key else "")
                       for c, t in columns)
   pg.script("CREATE TABLE IF NOT EXISTS %s (\n  %s\n);" % (ident(tbl), cols))
+  # A table migrated before a column existed gets it here, as resultsdb.py does.
+  pg.script("".join("ALTER TABLE %s ADD COLUMN IF NOT EXISTS %s %s;\n" % (ident(tbl), ident(c), t)
+                    for c, t in columns if c not in key))
 
 
 def read_progress(pg, source, tbl):

--- a/test.py
+++ b/test.py
@@ -1095,7 +1095,8 @@ def resultValues(model, libname, data, simulator=None):
     len(diff.get("vars") or []),
     diff.get("numCompared") or 0,
     simulated.get("phase") or 0,
-    data.get("parsing") or 0.0
+    data.get("parsing") or 0.0,
+    data.get("maxrss") or 0
   )
 
 def removedModels(resultBranch, libname, tested):
@@ -1113,7 +1114,9 @@ def removedModels(resultBranch, libname, tested):
 def removedValues(model, libname):
   """One row of a branch table saying the library no longer has that model."""
   return (testRunStartTimeAsEpoch, libname, model,
-          0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, shared.DELETED_PHASE, 0.0)
+          0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, shared.DELETED_PHASE, 0.0, 0)
+
+resultPlaceholders = ",".join("?" * len(resultsdb.BRANCH_COLUMNS))
 
 def cpu_name():
   if isWin:
@@ -1154,12 +1157,12 @@ for (resultBranch, runner) in resultBranches:
     (name,model,libname,data)=stats[key]
     if not ranRunner(libname, runner):
       continue
-    cursor.execute("INSERT INTO %s VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)%s" % (db.quote(resultBranch), db.insertIgnore()),
+    cursor.execute("INSERT INTO %s VALUES (%s)%s" % (db.quote(resultBranch), resultPlaceholders, db.insertIgnore()),
                    resultValues(model, libname, data, simulatorKey(libname, runner)))
   for libname in libnames:
     for model in removedModels(resultBranch, libname, testedModels[libname]):
-      cursor.execute("INSERT INTO %s VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)%s"
-                     % (db.quote(resultBranch), db.insertIgnore()),
+      cursor.execute("INSERT INTO %s VALUES (%s)%s"
+                     % (db.quote(resultBranch), resultPlaceholders, db.insertIgnore()),
                      removedValues(model, libname))
     confighash = stats_by_libname[libname]["conf"]["confighash"]
     cursor.execute("INSERT INTO libversion VALUES (?,?,?,?,?,?,?)%s" % db.insertIgnore(), (testRunStartTimeAsEpoch, resultBranch, libname, stats_by_libname[libname]["conf"]["libraryLastChange"], confighash, hostname, sysInfo))

--- a/testmodel.py
+++ b/testmodel.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import argparse, os, re, sys, signal, threading, psutil, subprocess, shutil
+import argparse, os, re, sys, signal, threading, psutil, subprocess, shutil, time
 from asyncio.subprocess import STDOUT
+try:
+  import resource
+except ImportError:
+  resource = None
 import simplejson as json
 from monotonic import monotonic
 from OMPython import FindBestOMCSession, OMCSession, OMCSessionZMQ
@@ -68,7 +72,78 @@ def phaseEnded():
   global runningPhase
   runningPhase = None
 
+pageSize = os.sysconf("SC_PAGE_SIZE") if hasattr(os, "sysconf") else 4096
+
+def descendants():
+  """Every process below this one. /proc/<pid>/task/*/children only touches
+  this tree, where psutil would scan all of /proc at every sample."""
+  if isWin:
+    return [p.pid for p in psutil.Process().children(recursive=True)]
+  pids = []
+  stack = [os.getpid()]
+  while stack:
+    pid = stack.pop()
+    try:
+      for tid in os.listdir("/proc/%d/task" % pid):
+        with open("/proc/%d/task/%s/children" % (pid, tid)) as fp:
+          kids = [int(c) for c in fp.read().split()]
+        pids += kids
+        stack += kids
+    except (OSError, ValueError):
+      pass
+  return pids
+
+def currentRss(pid):
+  try:
+    if isWin:
+      return psutil.Process(pid).memory_info().rss
+    with open("/proc/%d/statm" % pid) as fp:
+      return int(fp.read().split()[1]) * pageSize
+  except (OSError, ValueError, IndexError, psutil.Error):
+    return 0
+
+def peakRss(pid):
+  """The most memory a running process has had resident, in bytes."""
+  try:
+    if isWin:
+      return psutil.Process(pid).memory_info().peak_wset
+    with open("/proc/%d/status" % pid) as fp:
+      for line in fp:
+        if line.startswith("VmHWM:"):
+          return int(line.split()[1]) * 1024
+  except (OSError, ValueError, IndexError, psutil.Error):
+    pass
+  return 0
+
+# Sampled sum over the tree at one instant, and the kernel's exact peak of the
+# largest single process, which covers a spike between two samples.
+treePeak = 0
+processPeak = 0
+
+def sampleTree():
+  global treePeak
+  while True:
+    treePeak = max(treePeak, sum(currentRss(pid) for pid in descendants()))
+    time.sleep(0.2)
+
+def noteRss(rss):
+  global processPeak
+  processPeak = max(processPeak, rss)
+
+def noteChildrenRss():
+  """What is still running (omc lives on in a wasm-jit session) and what has
+  been waited for (make and its compilers, the simulation executable)."""
+  for pid in descendants():
+    noteRss(peakRss(pid))
+  if resource is not None:
+    maxrss = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
+    noteRss(maxrss if sys.platform == "darwin" else maxrss * 1024)
+
+threading.Thread(target=sampleTree, daemon=True).start()
+
 def writeResult():
+  noteChildrenRss()
+  execstat["maxrss"] = max(treePeak, processPeak)
   if runningPhase is not None:
     (stat, key, started) = runningPhase
     target = execstat if stat is None else stat
@@ -85,6 +160,9 @@ startJob=monotonic()
 def quit_omc(omc):
   if omc is None:
     return omc
+  process = getattr(omc, "_omc_process", None)
+  if process is not None:
+    noteRss(peakRss(process.pid))
   try:
     omc.sendExpression("quit()")
   except:
@@ -118,6 +196,7 @@ def killChildren(sig, name):
   """Signal everything this process started, one process at a time: Windows has no
   process group to signal instead."""
   for process in psutil.Process().children(recursive=True):
+    noteRss(peakRss(process.pid))
     try:
       os.kill(process.pid, sig)
     except (OSError, psutil.Error):
@@ -230,6 +309,7 @@ execstat = {
   "simcold":None,
   "diff":None,
   "phase":0,
+  "maxrss":0, # bytes resident at once across omc, compilers and executable
   # One entry per runner beyond the first, which reports itself in the keys
   # above; see configs/fmi-simulators.json, wasm-jit-runners.json, solvers.json.
   "simulators":{}

--- a/testresults.md
+++ b/testresults.md
@@ -71,6 +71,10 @@ run. For each tested model, the results of the following steps are reported:
 - _verification_: if reference results file are available, they are compared
   with the simulation results
 
+The database also records _maxrss_: the most resident memory, in bytes, that
+the processes testing the model held at any one time - omc, the compilers
+running beside it and the simulation executable added together.
+
 Clicking on the model name shows the log of phases from parsing to compilation.
 Clicking on the (sim) link shows the log of the runtime simulation.
 


### PR DESCRIPTION
A new maxrss column per branch table holds the most resident memory the model's process tree held at one instant: omc, the compilers make runs beside it and the simulation executable added together, in bytes.

testmodel.py samples the tree through /proc/<pid>/task/*/children and /proc/<pid>/statm five times a second, about 0.6% of one core per running model, and floors the result with the kernel's exact peak of the largest single process (VmHWM before quit or kill, and RUSAGE_CHILDREN for what was reaped) so a spike between two samples is not lost.

sqlite migrates to user_version 5 and PostgreSQL gets the column with ADD COLUMN IF NOT EXISTS; older rows read 0.

Assisted-by: Claude Fable 5.1