### PR TITLE
Filter the artifact run's result file

### DIFF
--- a/testmodel.py
+++ b/testmodel.py
@@ -911,10 +911,13 @@ def artifactCmd(runnerFlags, resFile):
   # An empty output format is a run with nothing to compare against, so it is
   # asked for no result file at all rather than one nobody reads.
   resultArgument = "-noemit" if outputFormat == "empty" else "-r=%s" % resFile
+  # The export baked in no filter, and the variableFilter argument below only
+  # reaches a model through the build this run skips.
+  filterArgument = "" if variableFilter in ("", ".*") else "-variableFilter=%s" % variableFilter
   simflags = " ".join(x for x in (annotationSimFlags, conf["simFlags"], emit_protected,
                                   "-lv LOG_STATS",
                                   "-startTime=%g -stopTime=%g -tolerance=%g -stepSize=%g" % (startTime,stopTime,tolerance,stepSize),
-                                  resultArgument, runnerFlags) if x.strip())
+                                  filterArgument, resultArgument, runnerFlags) if x.strip())
   return 'simulate(%s,startTime=%g,stopTime=%g,tolerance=%g,numberOfIntervals=%d,outputFormat="%s",variableFilter="%s",fileNamePrefix="%s",simflags="%s",resimulateExecutable="%s.fmu")' % (
       conf["modelName"],startTime,stopTime,tolerance,numberOfIntervals,outputFormat,variableFilter,conf["fileName"],simflags,conf["fileName"].replace(".","_"))
 


### PR DESCRIPTION
`simulate(variableFilter=…, resimulateExecutable=…)` keeps only `simflags`: the experiment arguments reach a model through the build, and a resimulate does not build. For the C lanes that is invisible, since the executable reads the filter from the `_init.xml` its own `buildModel` wrote, but a wasm artifact comes from `buildModelFMU`, which has no `variableFilter` argument. Every wasm-jit runner has therefore been writing every variable the model has. `artifactCmd` already passes the rest of the experiment as simflags for this same reason; `-variableFilter` was the one it missed.

Measured on the MSL 4.1.0 QuasiStatic FundamentalWave `IMC_Conveyor`, whose comparisonSignals.txt names three variables:

|                                 | no filter     | -variableFilter |
| ------------------------------- | ------------- | --------------- |
| result file                     | 1162 MB, 2857 | 4.97 MB, 3      |
| timeSimulation                  | 8.81 s        | 7.50 s          |
| verification, 500-row reference | 1.2-2.0 s     | 0.42 s          |
| verification, peak RSS          | 2.34 GB       | 71 MB           |

Over the 10801 models both lanes verified in the latest run, master's verification column sums to 788 s and wasm-jit's to 2216 s; the tail is the Buildings EnergyPlus and Borefields models and the MSL machines examples, which is exactly where the unfiltered files are widest.

Assisted-by: Claude Opus 5 (1M context)